### PR TITLE
Added route 'system/info' and info request struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ I.e.:
 		FunctionReader: handlers.MakeFunctionReader(clientset),
 		ReplicaReader:  handlers.MakeReplicaReader(clientset),
 		ReplicaUpdater: handlers.MakeReplicaUpdater(clientset),
+		InfoHandler:    handlers.MakeInfoHandler(),
 	}
 	var port int
 	port = 8080

--- a/serve.go
+++ b/serve.go
@@ -37,6 +37,8 @@ func Serve(handlers *types.FaaSHandlers, config *types.FaaSConfig) {
 	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}", handlers.FunctionProxy)
 	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/", handlers.FunctionProxy)
 
+	r.HandleFunc("/system/info", handlers.InfoHandler).Methods("GET")
+
 	if config.EnableHealth {
 		r.HandleFunc("/healthz", handlers.Health).Methods("GET")
 	}

--- a/types/config.go
+++ b/types/config.go
@@ -17,6 +17,7 @@ type FaaSHandlers struct {
 	// Optional: Update an existing function
 	UpdateHandler http.HandlerFunc
 	Health        http.HandlerFunc
+	InfoHandler   http.HandlerFunc
 }
 
 // FaaSConfig set config for HTTP handlers

--- a/types/requests.go
+++ b/types/requests.go
@@ -7,3 +7,16 @@ type ScaleServiceRequest struct {
 	ServiceName string `json:"serviceName"`
 	Replicas    uint64 `json:"replicas"`
 }
+
+// InfoRequest provides information about the underlying provider
+type InfoRequest struct {
+	Provider      string          `json:"provider"`
+	Version       ProviderVersion `json:"version"`
+	Orchestration string          `json:"orchestration"`
+}
+
+// ProviderVersion provides the commit sha and release version number of the underlying provider
+type ProviderVersion struct {
+	SHA     string `json:"sha"`
+	Release string `json:"release"`
+}


### PR DESCRIPTION
Resolves #5 

Added route 'system'/info' in order to provide the upstream gateway with information about the underlying provider

The upstream gateway can then show what provider is being used

This new route will provide the provider name, orchestration type, and a version object with sha and version number to the upstream gateway

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>