### PR TITLE
Add basic auth types from gateway

### DIFF
--- a/handlers/basic_auth.go
+++ b/handlers/basic_auth.go
@@ -1,0 +1,28 @@
+// Copyright (c) OpenFaaS Author(s). All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/openfaas/faas-provider/types"
+)
+
+// DecorateWithBasicAuth enforces basic auth as a middleware with given credentials
+func DecorateWithBasicAuth(next http.HandlerFunc, credentials *types.BasicAuthCredentials) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		user, password, ok := r.BasicAuth()
+		w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+
+		if !ok || credentials.Password != password || credentials.User != user {
+
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("invalid credentials"))
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	}
+}

--- a/types/config.go
+++ b/types/config.go
@@ -1,3 +1,6 @@
+// Copyright (c) OpenFaaS Author(s). All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package types
 
 import (

--- a/types/credentials.go
+++ b/types/credentials.go
@@ -1,0 +1,59 @@
+// Copyright (c) OpenFaaS Author(s). All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package types
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+	"regexp"
+	"strings"
+)
+
+// BasicAuthCredentials are the user and password strings
+type BasicAuthCredentials struct {
+	User     string
+	Password string
+}
+
+// ReadBasicAuth interface for reading the credentials
+type ReadBasicAuth interface {
+	Read() (error, *BasicAuthCredentials)
+}
+
+// ReadBasicAuthFromDisk defines the path for the secret
+type ReadBasicAuthFromDisk struct {
+	SecretMountPath string
+}
+
+func (r *ReadBasicAuthFromDisk) Read() (*BasicAuthCredentials, error) {
+	var credentials *BasicAuthCredentials
+
+	if len(r.SecretMountPath) == 0 {
+		return nil, fmt.Errorf("invalid SecretMountPath specified for reading secrets")
+	}
+
+	userPath := path.Join(r.SecretMountPath, "basic-auth-user")
+	user, userErr := ioutil.ReadFile(userPath)
+	if userErr != nil {
+		return nil, fmt.Errorf("unable to load %s", userPath)
+	}
+
+	userPassword := path.Join(r.SecretMountPath, "basic-auth-password")
+	password, passErr := ioutil.ReadFile(userPassword)
+	if passErr != nil {
+		return nil, fmt.Errorf("Unable to load %s", userPassword)
+	}
+
+	re := regexp.MustCompile(`\r?\n`)
+	user = re.ReplaceAll(user, []byte(" "))
+	password = re.ReplaceAll(password, []byte(" "))
+
+	credentials = &BasicAuthCredentials{
+		User:     strings.TrimSpace(string(user)),
+		Password: strings.TrimSpace(string(password)),
+	}
+
+	return credentials, nil
+}

--- a/types/requests.go
+++ b/types/requests.go
@@ -3,6 +3,7 @@
 
 package types
 
+// ScaleServiceRequest provides the ServiceName and number of Replicas to be scaled to
 type ScaleServiceRequest struct {
 	ServiceName string `json:"serviceName"`
 	Replicas    uint64 `json:"replicas"`


### PR DESCRIPTION
This changeset adds basic auth types and functions originally only
in the gateway. This will allow providers to perform authorization
checks independently. In cases like Swarm, where the functions are
accessible directly, this is needed to ensure calls are authorized

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

I also took the liberty of updating the copyright lines to ensure consistency across the projects.

This change is required in order to complete the issues in faas and faas-swarm:
https://github.com/openfaas/faas/issues/836
https://github.com/openfaas/faas-swarm/issues/31