### PR TITLE
Feature standardize function proxy handler

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,20 +2,24 @@
 
 
 [[projects]]
+  digest = "1:160eabf7a69910fd74f29c692718bc2437c1c1c7d4c9dea9712357752a70e5df"
   name = "github.com/gorilla/context"
   packages = ["."]
+  pruneopts = "UT"
   revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:e73f5b0152105f18bc131fba127d9949305c8693f8a762588a82a48f61756f5f"
   name = "github.com/gorilla/mux"
   packages = ["."]
-  revision = "7f08801859139f86dfafd1c296e2cba9a80d292e"
-  version = "v1.6.0"
+  pruneopts = "UT"
+  revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
+  version = "v1.6.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "22efb1c7d9d2403520db6d9a878b2f1e52741e51425cbda743cfd25f00c84a9b"
+  input-imports = ["github.com/gorilla/mux"]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,4 +4,4 @@
 
 [[constraint]]
   name = "github.com/gorilla/mux"
-  version = "1.6.0"
+  version = "1.6.2"

--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -1,0 +1,140 @@
+package handlers
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/openfaas/faas/gateway/requests"
+)
+
+const (
+	watchdogPort       = 8080
+	defaultContentType = "text/plain"
+)
+
+// MakeProxyHandler creates a standard http HandlerFunc to proxy function requests to the function.
+// The FaaS provider implementation is responsible for providing the resolver function implementation.
+// resolver will receive the function name and should return the address of the function service.
+func MakeProxyHandler(timeout time.Duration, resolver func(string) string) http.HandlerFunc {
+	proxyClient := http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   timeout,
+				KeepAlive: 1 * time.Second,
+			}).DialContext,
+			IdleConnTimeout:       120 * time.Millisecond,
+			ExpectContinueTimeout: 1500 * time.Millisecond,
+		},
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil {
+			defer r.Body.Close()
+		}
+
+		switch r.Method {
+		case http.MethodPost,
+			http.MethodPut,
+			http.MethodPatch,
+			http.MethodDelete,
+			http.MethodGet:
+
+			proxyRequest(w, r, proxyClient, resolver)
+
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+// proxyRequest handles the actual resolution of and then request to the function service.
+func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient http.Client, resolver func(string) string) {
+
+	functionName := getFunctionName(originalReq)
+	if functionName == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Provide an x-function header or valid route /function/function_name."))
+		return
+	}
+
+	functionAddr := resolver(functionName)
+	if functionAddr == "" {
+		// TODO: Should record the 404/not found error in Prometheus.
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(fmt.Sprintf("Cannot find service: %s.", functionName)))
+		return
+	}
+
+	defer func(when time.Time) {
+		seconds := time.Since(when).Seconds()
+		log.Printf("%s took %f seconds\n", functionName, seconds)
+	}(time.Now())
+
+	forwardReq := requests.NewForwardRequest(originalReq.Method, *originalReq.URL)
+	url := forwardReq.ToURL(functionAddr, watchdogPort)
+	proxyReq, _ := http.NewRequest(originalReq.Method, url, originalReq.Body)
+	defer proxyReq.Body.Close()
+
+	copyHeaders(&proxyReq.Header, &originalReq.Header)
+
+	response, err := proxyClient.Do(proxyReq)
+	if err != nil {
+		log.Println("[ERROR]", err.Error())
+		w.WriteHeader(http.StatusInternalServerError)
+		buf := bytes.NewBufferString("Can't reach service for: " + functionName)
+		w.Write(buf.Bytes())
+		return
+	}
+
+	clientHeader := w.Header()
+	copyHeaders(&clientHeader, &response.Header)
+	w.Header().Set("Content-Type", getContentType(response.Header, originalReq.Header))
+
+	w.WriteHeader(http.StatusOK)
+	io.Copy(w, response.Body)
+}
+
+// getFunctionName inspects the request and returns the specified function.  This allows the
+// caller to specify the function via the X-Function header or as part to the URL path.  The
+// name found in the header is ignored if a name can be found in the URL path.
+func getFunctionName(r *http.Request) (functionName string) {
+	functionName = mux.Vars(r)["name"]
+	if functionName == "" {
+		functionName = r.Header.Get("X-Function")
+		log.Print("trying X-Function header, found: ", functionName)
+	}
+
+	return functionName
+}
+
+// copyHeaders clones the header values from the source into the destination.
+func copyHeaders(destination *http.Header, source *http.Header) {
+	for k, v := range *source {
+		vClone := make([]string, len(v))
+		copy(vClone, v)
+		(*destination)[k] = vClone
+	}
+}
+
+// getContentType resolves the correct Content-Tyoe for a proxied function.
+func getContentType(request http.Header, proxyResponse http.Header) (headerContentType string) {
+	responseHeader := proxyResponse.Get("Content-Type")
+	requestHeader := request.Get("Content-Type")
+
+	if len(responseHeader) > 0 {
+		headerContentType = responseHeader
+	} else if len(requestHeader) > 0 {
+		headerContentType = requestHeader
+	} else {
+		headerContentType = defaultContentType
+	}
+
+	return headerContentType
+}

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -1,18 +1,29 @@
 package proxy
 
 import (
+	"bytes"
+	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/gorilla/mux"
 )
 
 type testBaseURLResolver struct {
 	testServerBase string
+	err            error
 }
 
 func (tr *testBaseURLResolver) Resolve(name string) (url.URL, error) {
+	if tr.err != nil {
+		return url.URL{}, tr.err
+	}
+
 	return url.URL{
 		Scheme: "http",
 		Host:   tr.testServerBase,
@@ -60,4 +71,64 @@ func Test_ProxyHandler_NonAllowedMethods(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_ProxyHandler_MissingFunctionNameError(t *testing.T) {
+	proxyFunc := NewHandlerFunc(time.Second, &testBaseURLResolver{"", nil})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+	req = mux.SetURLVars(req, map[string]string{"name": ""})
+
+	proxyFunc(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status code `%d`, got `%d`", http.StatusBadRequest, w.Code)
+	}
+
+	respBody := w.Body.String()
+	if respBody != errMissingFunctionName {
+		t.Errorf("expected error message `%s`, got `%s`", errMissingFunctionName, respBody)
+	}
+}
+
+func Test_ProxyHandler_ResolveError(t *testing.T) {
+	logs := &bytes.Buffer{}
+	log.SetOutput(logs)
+
+	resolveErr := errors.New("can not find test service `foo`")
+	proxyFunc := NewHandlerFunc(time.Second, &testBaseURLResolver{"", resolveErr})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+	req = mux.SetURLVars(req, map[string]string{"name": "foo"})
+
+	proxyFunc(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected status code `%d`, got `%d`", http.StatusBadRequest, w.Code)
+	}
+
+	respBody := w.Body.String()
+	if respBody != "Cannot find service: foo." {
+		t.Errorf("expected error message `%s`, got `%s`", "Cannot find service: foo.", respBody)
+	}
+
+	if !strings.Contains(logs.String(), resolveErr.Error()) {
+		t.Errorf("expected logs to contain `%s`", resolveErr.Error())
+	}
+}
+
+func Test_ProxyHandler_Proxy_Success(t *testing.T) {
+	t.Skip("Test not implemented yet")
+	// testFuncService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// 	w.WriteHeader(http.StatusOK)
+	// }))
+	// proxyFunc := NewHandlerFunc(time.Second, &testBaseURLResolver{testFuncService.URL, nil})
+
+	// w := httptest.NewRecorder()
+	// req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+	// req = mux.SetURLVars(req, map[string]string{"name": "foo"})
+
+	// proxyFunc(w, req)
 }

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -1,0 +1,63 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+type testBaseURLResolver struct {
+	testServerBase string
+}
+
+func (tr *testBaseURLResolver) Resolve(name string) (url.URL, error) {
+	return url.URL{
+		Scheme: "http",
+		Host:   tr.testServerBase,
+	}, nil
+}
+func Test_NewHandlerFunc_Panic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("should panic if resolver is nil")
+		}
+	}()
+
+	NewHandlerFunc(time.Second, nil)
+}
+
+func Test_NewHandlerFunc_NoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("should not panic if resolver is not nil")
+		}
+	}()
+
+	proxyFunc := NewHandlerFunc(time.Second, &testBaseURLResolver{})
+	if proxyFunc == nil {
+		t.Errorf("proxy handler func is nil")
+	}
+}
+
+func Test_ProxyHandler_NonAllowedMethods(t *testing.T) {
+
+	proxyFunc := NewHandlerFunc(time.Second, &testBaseURLResolver{})
+
+	nonAllowedMethods := []string{
+		http.MethodHead, http.MethodConnect, http.MethodOptions, http.MethodTrace,
+	}
+
+	for _, method := range nonAllowedMethods {
+		t.Run(method+" method is not allowed", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(method, "http://example.com/foo", nil)
+			proxyFunc(w, req)
+			resp := w.Result()
+			if resp.StatusCode != http.StatusMethodNotAllowed {
+				t.Errorf("expected status code `%d`, got `%d`", http.StatusMethodNotAllowed, resp.StatusCode)
+			}
+		})
+	}
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -23,7 +23,7 @@ const (
 // BaseURLResolver.Resolve will receive the function name and should return the base Address of the
 // function service.
 type BaseURLResolver interface {
-	Resolve(functionName string) string
+	Resolve(functionName string) (string, error)
 }
 
 // NewHandlerFunc creates a standard http HandlerFunc to proxy function requests to the function.
@@ -71,9 +71,10 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 		return
 	}
 
-	functionAddr := resolver.Resolve(functionName)
-	if functionAddr == "" {
+	functionAddr, resolveErr := resolver.Resolve(functionName)
+	if resolveErr != nil {
 		// TODO: Should record the 404/not found error in Prometheus.
+		log.Printf("resolver error: cannot find %s: %s\n", functionName, resolveErr.Error())
 		writeError(w, http.StatusNotFound, "Cannot find service: %s.", functionName)
 		return
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -33,8 +33,9 @@ import (
 )
 
 const (
-	watchdogPort       = "8080"
-	defaultContentType = "text/plain"
+	watchdogPort           = "8080"
+	defaultContentType     = "text/plain"
+	errMissingFunctionName = "Please provide a valid route /function/function_name."
 )
 
 // BaseURLResolver URL resolver for proxy requests
@@ -111,7 +112,7 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 	pathVars := mux.Vars(originalReq)
 	functionName := pathVars["name"]
 	if functionName == "" {
-		writeError(w, http.StatusBadRequest, "Please provide a valid route /function/function_name.")
+		writeError(w, http.StatusBadRequest, errMissingFunctionName)
 		return
 	}
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -38,6 +38,10 @@ func NewHandlerFunc(timeout time.Duration, resolver BaseURLResolver) http.Handle
 			IdleConnTimeout:       120 * time.Millisecond,
 			ExpectContinueTimeout: 1500 * time.Millisecond,
 		},
+		Timeout: timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -20,7 +20,8 @@ const (
 // BaseURLResolver URL resolver for proxy requests
 //
 // The FaaS provider implementation is responsible for providing the resolver function implementation.
-// resolver will receive the function name and should return the address of the function service.
+// BaseURLResolver.Resolve will receive the function name and should return the base Address of the
+// function service.
 type BaseURLResolver interface {
 	Resolve(functionName string) string
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -61,6 +61,7 @@ func NewHandlerFunc(timeout time.Duration, resolver BaseURLResolver) http.Handle
 
 // proxyRequest handles the actual resolution of and then request to the function service.
 func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient http.Client, resolver BaseURLResolver) {
+	ctx := originalReq.Context()
 
 	pathVars := mux.Vars(originalReq)
 	functionName := pathVars["name"]
@@ -84,7 +85,7 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 	defer proxyReq.Body.Close()
 
 	start := time.Now()
-	response, err := proxyClient.Do(proxyReq)
+	response, err := proxyClient.Do(proxyReq.WithContext(ctx))
 	seconds := time.Since(start)
 
 	if err != nil {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -15,6 +16,13 @@ func varHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(fmt.Sprintf("name: %s params: %s", vars["name"], vars["params"])))
+}
+
+func testResolver(functionName string) (url.URL, error) {
+	return url.URL{
+		Scheme: "http",
+		Host:   functionName,
+	}, nil
 }
 
 func Test_pathParsing(t *testing.T) {
@@ -102,7 +110,8 @@ func Test_buildProxyRequest_Body_Method_Query(t *testing.T) {
 		t.Fail()
 	}
 
-	upstream, err := buildProxyRequest(request, "funcName", "")
+	funcURL, _ := testResolver("funcName")
+	upstream, err := buildProxyRequest(request, funcURL, "")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -134,7 +143,8 @@ func Test_buildProxyRequest_Body_Method_Query(t *testing.T) {
 func Test_buildProxyRequest_NoBody_GetMethod_NoQuery(t *testing.T) {
 	request, _ := http.NewRequest(http.MethodGet, "/", nil)
 
-	upstream, err := buildProxyRequest(request, "funcName", "")
+	funcURL, _ := testResolver("funcName")
+	upstream, err := buildProxyRequest(request, funcURL, "")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -166,7 +176,8 @@ func Test_buildProxyRequest_HasXForwardedHostHeaderWhenSet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	upstream, err := buildProxyRequest(request, "funcName", "/")
+	funcURL, _ := testResolver("funcName")
+	upstream, err := buildProxyRequest(request, funcURL, "/")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -186,7 +197,8 @@ func Test_buildProxyRequest_XForwardedHostHeader_Empty_WhenNotSet(t *testing.T) 
 		t.Fatal(err)
 	}
 
-	upstream, err := buildProxyRequest(request, "funcName", "/")
+	funcURL, _ := testResolver("funcName")
+	upstream, err := buildProxyRequest(request, funcURL, "/")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -207,7 +219,8 @@ func Test_buildProxyRequest_XForwardedHostHeader_WhenAlreadyPresent(t *testing.T
 	}
 
 	request.Header.Set("X-Forwarded-Host", headerValue)
-	upstream, err := buildProxyRequest(request, "funcName", "/")
+	funcURL, _ := testResolver("funcName")
+	upstream, err := buildProxyRequest(request, funcURL, "/")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -234,7 +247,8 @@ func Test_buildProxyRequest_WithPathNoQuery(t *testing.T) {
 		t.Fail()
 	}
 
-	upstream, err := buildProxyRequest(request, "xyz", functionPath)
+	funcURL, _ := testResolver("xyz")
+	upstream, err := buildProxyRequest(request, funcURL, functionPath)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -285,7 +299,8 @@ func Test_buildProxyRequest_WithNoPathNoQuery(t *testing.T) {
 		t.Fail()
 	}
 
-	upstream, err := buildProxyRequest(request, "xyz", functionPath)
+	funcURL, _ := testResolver("xyz")
+	upstream, err := buildProxyRequest(request, funcURL, functionPath)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -334,7 +349,8 @@ func Test_buildProxyRequest_WithPathAndQuery(t *testing.T) {
 		t.Fail()
 	}
 
-	upstream, err := buildProxyRequest(request, "xyz", functionPath)
+	funcURL, _ := testResolver("xyz")
+	upstream, err := buildProxyRequest(request, funcURL, functionPath)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1,0 +1,369 @@
+package proxy
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func varHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(fmt.Sprintf("name: %s params: %s", vars["name"], vars["params"])))
+}
+
+func Test_pathParsing(t *testing.T) {
+	tt := []struct {
+		name         string
+		functionPath string
+		functionName string
+		extraPath    string
+		statusCode   int
+	}{
+		{
+			"simple_name_match",
+			"/function/echo",
+			"echo",
+			"",
+			200,
+		},
+		{
+			"simple_name_match_with_trailing_slash",
+			"/function/echo/",
+			"echo",
+			"",
+			200,
+		},
+		{
+			"name_match_with_additional_path_values",
+			"/function/echo/subPath/extras",
+			"echo",
+			"subPath/extras",
+			200,
+		},
+		{
+			"name_match_with_additional_path_values_and_querystring",
+			"/function/echo/subPath/extras?query=true",
+			"echo",
+			"subPath/extras",
+			200,
+		},
+		{
+			"not_found_if_no_name",
+			"/function/",
+			"",
+			"",
+			404,
+		},
+	}
+
+	// Need to create a router that we can pass the request through so that the vars will be added to the context
+	router := mux.NewRouter()
+	router.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}", varHandler)
+	router.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/", varHandler)
+	router.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/{params:.*}", varHandler)
+
+	for _, s := range tt {
+		t.Run(s.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req, err := http.NewRequest("GET", s.functionPath, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			router.ServeHTTP(rr, req)
+			if rr.Code != s.statusCode {
+				t.Fatalf("unexpected status code; got: %d, expected: %d", rr.Code, s.statusCode)
+			}
+
+			body := rr.Body.String()
+			expectedBody := fmt.Sprintf("name: %s params: %s", s.functionName, s.extraPath)
+			if s.statusCode == http.StatusOK && body != expectedBody {
+				t.Fatalf("incorrect function name and path params; got: %s, expected: %s", body, expectedBody)
+			}
+		})
+	}
+}
+
+func Test_buildProxyRequest_Body_Method_Query(t *testing.T) {
+	srcBytes := []byte("hello world")
+
+	reader := bytes.NewReader(srcBytes)
+	request, _ := http.NewRequest(http.MethodPost, "/?code=1", reader)
+	request.Header.Set("X-Source", "unit-test")
+
+	if request.URL.RawQuery != "code=1" {
+		t.Errorf("Query - want: %s, got: %s", "code=1", request.URL.RawQuery)
+		t.Fail()
+	}
+
+	upstream, err := buildProxyRequest(request, "funcName", "")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if request.Method != upstream.Method {
+		t.Errorf("Method - want: %s, got: %s", request.Method, upstream.Method)
+		t.Fail()
+	}
+
+	upstreamBytes, _ := ioutil.ReadAll(upstream.Body)
+
+	if string(upstreamBytes) != string(srcBytes) {
+		t.Errorf("Body - want: %s, got: %s", string(upstreamBytes), string(srcBytes))
+		t.Fail()
+	}
+
+	if request.Header.Get("X-Source") != upstream.Header.Get("X-Source") {
+		t.Errorf("Header X-Source - want: %s, got: %s", request.Header.Get("X-Source"), upstream.Header.Get("X-Source"))
+		t.Fail()
+	}
+
+	if request.URL.RawQuery != upstream.URL.RawQuery {
+		t.Errorf("URL.RawQuery - want: %s, got: %s", request.URL.RawQuery, upstream.URL.RawQuery)
+		t.Fail()
+	}
+
+}
+
+func Test_buildProxyRequest_NoBody_GetMethod_NoQuery(t *testing.T) {
+	request, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	upstream, err := buildProxyRequest(request, "funcName", "")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if request.Method != upstream.Method {
+		t.Errorf("Method - want: %s, got: %s", request.Method, upstream.Method)
+		t.Fail()
+	}
+
+	if upstream.Body != nil {
+		t.Errorf("Body - expected nil")
+		t.Fail()
+	}
+
+	if request.URL.RawQuery != upstream.URL.RawQuery {
+		t.Errorf("URL.RawQuery - want: %s, got: %s", request.URL.RawQuery, upstream.URL.RawQuery)
+		t.Fail()
+	}
+
+}
+
+func Test_buildProxyRequest_HasXForwardedHostHeaderWhenSet(t *testing.T) {
+	srcBytes := []byte("hello world")
+
+	reader := bytes.NewReader(srcBytes)
+	request, err := http.NewRequest(http.MethodPost, "http://gateway/function?code=1", reader)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	upstream, err := buildProxyRequest(request, "funcName", "/")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if request.Host != upstream.Header.Get("X-Forwarded-Host") {
+		t.Errorf("Host - want: %s, got: %s", request.Host, upstream.Header.Get("X-Forwarded-Host"))
+	}
+}
+
+func Test_buildProxyRequest_XForwardedHostHeader_Empty_WhenNotSet(t *testing.T) {
+	srcBytes := []byte("hello world")
+
+	reader := bytes.NewReader(srcBytes)
+	request, err := http.NewRequest(http.MethodPost, "/function", reader)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	upstream, err := buildProxyRequest(request, "funcName", "/")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if request.Host != upstream.Header.Get("X-Forwarded-Host") {
+		t.Errorf("Host - want: %s, got: %s", request.Host, upstream.Header.Get("X-Forwarded-Host"))
+	}
+}
+
+func Test_buildProxyRequest_XForwardedHostHeader_WhenAlreadyPresent(t *testing.T) {
+	srcBytes := []byte("hello world")
+	headerValue := "test.openfaas.com"
+	reader := bytes.NewReader(srcBytes)
+	request, err := http.NewRequest(http.MethodPost, "/function/test", reader)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request.Header.Set("X-Forwarded-Host", headerValue)
+	upstream, err := buildProxyRequest(request, "funcName", "/")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if upstream.Header.Get("X-Forwarded-Host") != headerValue {
+		t.Errorf("X-Forwarded-Host - want: %s, got: %s", headerValue, upstream.Header.Get("X-Forwarded-Host"))
+	}
+}
+
+func Test_buildProxyRequest_WithPathNoQuery(t *testing.T) {
+	srcBytes := []byte("hello world")
+	functionPath := "/employee/info/300"
+
+	requestPath := fmt.Sprintf("/function/xyz%s", functionPath)
+
+	reader := bytes.NewReader(srcBytes)
+	request, _ := http.NewRequest(http.MethodPost, requestPath, reader)
+	request.Header.Set("X-Source", "unit-test")
+
+	queryWant := ""
+	if request.URL.RawQuery != queryWant {
+
+		t.Errorf("Query - want: %s, got: %s", queryWant, request.URL.RawQuery)
+		t.Fail()
+	}
+
+	upstream, err := buildProxyRequest(request, "xyz", functionPath)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if request.Method != upstream.Method {
+		t.Errorf("Method - want: %s, got: %s", request.Method, upstream.Method)
+		t.Fail()
+	}
+
+	upstreamBytes, _ := ioutil.ReadAll(upstream.Body)
+
+	if string(upstreamBytes) != string(srcBytes) {
+		t.Errorf("Body - want: %s, got: %s", string(upstreamBytes), string(srcBytes))
+		t.Fail()
+	}
+
+	if request.Header.Get("X-Source") != upstream.Header.Get("X-Source") {
+		t.Errorf("Header X-Source - want: %s, got: %s", request.Header.Get("X-Source"), upstream.Header.Get("X-Source"))
+		t.Fail()
+	}
+
+	if request.URL.RawQuery != upstream.URL.RawQuery {
+		t.Errorf("URL.RawQuery - want: %s, got: %s", request.URL.RawQuery, upstream.URL.RawQuery)
+		t.Fail()
+	}
+
+	if functionPath != upstream.URL.Path {
+		t.Errorf("URL.Path - want: %s, got: %s", functionPath, upstream.URL.Path)
+		t.Fail()
+	}
+
+}
+
+func Test_buildProxyRequest_WithNoPathNoQuery(t *testing.T) {
+	srcBytes := []byte("hello world")
+	functionPath := "/"
+
+	requestPath := fmt.Sprintf("/function/xyz%s", functionPath)
+
+	reader := bytes.NewReader(srcBytes)
+	request, _ := http.NewRequest(http.MethodPost, requestPath, reader)
+	request.Header.Set("X-Source", "unit-test")
+
+	queryWant := ""
+	if request.URL.RawQuery != queryWant {
+
+		t.Errorf("Query - want: %s, got: %s", queryWant, request.URL.RawQuery)
+		t.Fail()
+	}
+
+	upstream, err := buildProxyRequest(request, "xyz", functionPath)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if request.Method != upstream.Method {
+		t.Errorf("Method - want: %s, got: %s", request.Method, upstream.Method)
+		t.Fail()
+	}
+
+	upstreamBytes, _ := ioutil.ReadAll(upstream.Body)
+
+	if string(upstreamBytes) != string(srcBytes) {
+		t.Errorf("Body - want: %s, got: %s", string(upstreamBytes), string(srcBytes))
+		t.Fail()
+	}
+
+	if request.Header.Get("X-Source") != upstream.Header.Get("X-Source") {
+		t.Errorf("Header X-Source - want: %s, got: %s", request.Header.Get("X-Source"), upstream.Header.Get("X-Source"))
+		t.Fail()
+	}
+
+	if request.URL.RawQuery != upstream.URL.RawQuery {
+		t.Errorf("URL.RawQuery - want: %s, got: %s", request.URL.RawQuery, upstream.URL.RawQuery)
+		t.Fail()
+	}
+
+	if functionPath != upstream.URL.Path {
+		t.Errorf("URL.Path - want: %s, got: %s", functionPath, upstream.URL.Path)
+		t.Fail()
+	}
+
+}
+
+func Test_buildProxyRequest_WithPathAndQuery(t *testing.T) {
+	srcBytes := []byte("hello world")
+	functionPath := "/employee/info/300"
+
+	requestPath := fmt.Sprintf("/function/xyz%s?code=1", functionPath)
+
+	reader := bytes.NewReader(srcBytes)
+	request, _ := http.NewRequest(http.MethodPost, requestPath, reader)
+	request.Header.Set("X-Source", "unit-test")
+
+	if request.URL.RawQuery != "code=1" {
+		t.Errorf("Query - want: %s, got: %s", "code=1", request.URL.RawQuery)
+		t.Fail()
+	}
+
+	upstream, err := buildProxyRequest(request, "xyz", functionPath)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if request.Method != upstream.Method {
+		t.Errorf("Method - want: %s, got: %s", request.Method, upstream.Method)
+		t.Fail()
+	}
+
+	upstreamBytes, _ := ioutil.ReadAll(upstream.Body)
+
+	if string(upstreamBytes) != string(srcBytes) {
+		t.Errorf("Body - want: %s, got: %s", string(upstreamBytes), string(srcBytes))
+		t.Fail()
+	}
+
+	if request.Header.Get("X-Source") != upstream.Header.Get("X-Source") {
+		t.Errorf("Header X-Source - want: %s, got: %s", request.Header.Get("X-Source"), upstream.Header.Get("X-Source"))
+		t.Fail()
+	}
+
+	if request.URL.RawQuery != upstream.URL.RawQuery {
+		t.Errorf("URL.RawQuery - want: %s, got: %s", request.URL.RawQuery, upstream.URL.RawQuery)
+		t.Fail()
+	}
+
+	if functionPath != upstream.URL.Path {
+		t.Errorf("URL.Path - want: %s, got: %s", functionPath, upstream.URL.Path)
+		t.Fail()
+	}
+
+}

--- a/serve.go
+++ b/serve.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/openfaas/faas-provider/auth"
-	"github.com/openfaas/faas-provider/proxy"
 	"github.com/openfaas/faas-provider/types"
 )
 
@@ -49,7 +48,6 @@ func Serve(handlers *types.FaaSHandlers, config *types.FaaSConfig) {
 	}
 
 	// System (auth) endpoints
-
 	r.HandleFunc("/system/functions", handlers.FunctionReader).Methods("GET")
 	r.HandleFunc("/system/functions", handlers.DeployHandler).Methods("POST")
 	r.HandleFunc("/system/functions", handlers.DeleteHandler).Methods("DELETE")
@@ -60,10 +58,9 @@ func Serve(handlers *types.FaaSHandlers, config *types.FaaSConfig) {
 	r.HandleFunc("/system/info", handlers.InfoHandler).Methods("GET")
 
 	// Open endpoints
-	functionProxy := proxy.NewHandlerFunc(config.ReadTimeout, config.FunctionProxyResolver)
-	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}", functionProxy)
-	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/", functionProxy)
-	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/{params:.*}", functionProxy)
+	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}", handlers.FunctionProxy)
+	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/", handlers.FunctionProxy)
+	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/{params:.*}", handlers.FunctionProxy)
 
 	if config.EnableHealth {
 		r.HandleFunc("/healthz", handlers.Health).Methods("GET")

--- a/serve.go
+++ b/serve.go
@@ -48,6 +48,7 @@ func Serve(handlers *types.FaaSHandlers, config *types.FaaSConfig) {
 	}
 
 	// System (auth) endpoints
+
 	r.HandleFunc("/system/functions", handlers.FunctionReader).Methods("GET")
 	r.HandleFunc("/system/functions", handlers.DeployHandler).Methods("POST")
 	r.HandleFunc("/system/functions", handlers.DeleteHandler).Methods("DELETE")
@@ -60,6 +61,7 @@ func Serve(handlers *types.FaaSHandlers, config *types.FaaSConfig) {
 	// Open endpoints
 	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}", handlers.FunctionProxy)
 	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/", handlers.FunctionProxy)
+	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/{params:.*}", handlers.FunctionProxy)
 
 	if config.EnableHealth {
 		r.HandleFunc("/healthz", handlers.Health).Methods("GET")

--- a/serve.go
+++ b/serve.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/openfaas/faas-provider/auth"
+	"github.com/openfaas/faas-provider/proxy"
 	"github.com/openfaas/faas-provider/types"
 )
 
@@ -59,9 +60,10 @@ func Serve(handlers *types.FaaSHandlers, config *types.FaaSConfig) {
 	r.HandleFunc("/system/info", handlers.InfoHandler).Methods("GET")
 
 	// Open endpoints
-	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}", handlers.FunctionProxy)
-	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/", handlers.FunctionProxy)
-	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/{params:.*}", handlers.FunctionProxy)
+	functionProxy := proxy.NewHandlerFunc(config.ReadTimeout, config.FunctionProxyResolver)
+	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}", functionProxy)
+	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/", functionProxy)
+	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/{params:.*}", functionProxy)
 
 	if config.EnableHealth {
 		r.HandleFunc("/healthz", handlers.Health).Methods("GET")

--- a/types/config.go
+++ b/types/config.go
@@ -3,14 +3,15 @@ package types
 import (
 	"net/http"
 	"time"
-
-	"github.com/openfaas/faas-provider/proxy"
 )
 
 // FaaSHandlers provide handlers for OpenFaaS
 type FaaSHandlers struct {
 	FunctionReader http.HandlerFunc
 	DeployHandler  http.HandlerFunc
+	// FunctionProxy provides the function invocation proxy logic.  Use proxy.NewHandlerFunc to
+	// use the standard OpenFaaS proxy implementation or provide completely custom proxy logic.
+	FunctionProxy  http.HandlerFunc
 	DeleteHandler  http.HandlerFunc
 	ReplicaReader  http.HandlerFunc
 	ReplicaUpdater http.HandlerFunc
@@ -29,9 +30,4 @@ type FaaSConfig struct {
 	EnableHealth    bool
 	EnableBasicAuth bool
 	SecretMountPath string
-
-	// The FaaS provider implementation is responsible for providing the resolver function implementation.
-	// BaseURLResolver.Resolve will receive the function name and should return the base Address of the
-	// function service.
-	FunctionProxyResolver proxy.BaseURLResolver
 }

--- a/types/config.go
+++ b/types/config.go
@@ -3,6 +3,8 @@ package types
 import (
 	"net/http"
 	"time"
+
+	"github.com/openfaas/faas-provider/proxy"
 )
 
 // FaaSHandlers provide handlers for OpenFaaS
@@ -11,7 +13,6 @@ type FaaSHandlers struct {
 	DeployHandler  http.HandlerFunc
 	DeleteHandler  http.HandlerFunc
 	ReplicaReader  http.HandlerFunc
-	FunctionProxy  http.HandlerFunc
 	ReplicaUpdater http.HandlerFunc
 
 	// Optional: Update an existing function
@@ -28,4 +29,9 @@ type FaaSConfig struct {
 	EnableHealth    bool
 	EnableBasicAuth bool
 	SecretMountPath string
+
+	// The FaaS provider implementation is responsible for providing the resolver function implementation.
+	// BaseURLResolver.Resolve will receive the function name and should return the base Address of the
+	// function service.
+	FunctionProxyResolver proxy.BaseURLResolver
 }

--- a/vendor/github.com/gorilla/mux/.travis.yml
+++ b/vendor/github.com/gorilla/mux/.travis.yml
@@ -3,11 +3,12 @@ sudo: false
 
 matrix:
   include:
-    - go: 1.5
-    - go: 1.6
-    - go: 1.7
-    - go: 1.8
-    - go: 1.9
+    - go: 1.5.x
+    - go: 1.6.x
+    - go: 1.7.x
+    - go: 1.8.x
+    - go: 1.9.x
+    - go: 1.10.x
     - go: tip
   allow_failures:
     - go: tip

--- a/vendor/github.com/gorilla/mux/ISSUE_TEMPLATE.md
+++ b/vendor/github.com/gorilla/mux/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+**What version of Go are you running?** (Paste the output of `go version`)
+
+
+**What version of gorilla/mux are you at?** (Paste the output of `git rev-parse HEAD` inside `$GOPATH/src/github.com/gorilla/mux`)
+
+
+**Describe your problem** (and what you have tried so far)
+
+
+**Paste a minimal, runnable, reproduction of your issue below** (use backticks to format it)
+

--- a/vendor/github.com/gorilla/mux/README.md
+++ b/vendor/github.com/gorilla/mux/README.md
@@ -1,5 +1,5 @@
-gorilla/mux
-===
+# gorilla/mux
+
 [![GoDoc](https://godoc.org/github.com/gorilla/mux?status.svg)](https://godoc.org/github.com/gorilla/mux)
 [![Build Status](https://travis-ci.org/gorilla/mux.svg?branch=master)](https://travis-ci.org/gorilla/mux)
 [![Sourcegraph](https://sourcegraph.com/github.com/gorilla/mux/-/badge.svg)](https://sourcegraph.com/github.com/gorilla/mux?badge)
@@ -27,6 +27,9 @@ The name mux stands for "HTTP request multiplexer". Like the standard `http.Serv
 * [Static Files](#static-files)
 * [Registered URLs](#registered-urls)
 * [Walking Routes](#walking-routes)
+* [Graceful Shutdown](#graceful-shutdown)
+* [Middleware](#middleware)
+* [Testing Handlers](#testing-handlers)
 * [Full Example](#full-example)
 
 ---
@@ -45,11 +48,11 @@ Let's start registering a couple of URL paths and handlers:
 
 ```go
 func main() {
-	r := mux.NewRouter()
-	r.HandleFunc("/", HomeHandler)
-	r.HandleFunc("/products", ProductsHandler)
-	r.HandleFunc("/articles", ArticlesHandler)
-	http.Handle("/", r)
+    r := mux.NewRouter()
+    r.HandleFunc("/", HomeHandler)
+    r.HandleFunc("/products", ProductsHandler)
+    r.HandleFunc("/articles", ArticlesHandler)
+    http.Handle("/", r)
 }
 ```
 
@@ -68,9 +71,9 @@ The names are used to create a map of route variables which can be retrieved cal
 
 ```go
 func ArticlesCategoryHandler(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, "Category: %v\n", vars["category"])
+    vars := mux.Vars(r)
+    w.WriteHeader(http.StatusOK)
+    fmt.Fprintf(w, "Category: %v\n", vars["category"])
 }
 ```
 
@@ -122,7 +125,7 @@ r.Queries("key", "value")
 
 ```go
 r.MatcherFunc(func(r *http.Request, rm *RouteMatch) bool {
-	return r.ProtoMajor == 0
+    return r.ProtoMajor == 0
 })
 ```
 
@@ -176,91 +179,34 @@ s.HandleFunc("/{key}/", ProductHandler)
 // "/products/{key}/details"
 s.HandleFunc("/{key}/details", ProductDetailsHandler)
 ```
-### Listing Routes
 
-Routes on a mux can be listed using the Router.Walk method—useful for generating documentation:
-
-```go
-package main
-
-import (
-    "fmt"
-    "net/http"
-    "strings"
-
-    "github.com/gorilla/mux"
-)
-
-func handler(w http.ResponseWriter, r *http.Request) {
-    return
-}
-
-func main() {
-    r := mux.NewRouter()
-    r.HandleFunc("/", handler)
-    r.HandleFunc("/products", handler).Methods("POST")
-    r.HandleFunc("/articles", handler).Methods("GET")
-    r.HandleFunc("/articles/{id}", handler).Methods("GET", "PUT")
-    r.HandleFunc("/authors", handler).Queries("surname", "{surname}")
-    r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
-        t, err := route.GetPathTemplate()
-        if err != nil {
-            return err
-        }
-        qt, err := route.GetQueriesTemplates()
-        if err != nil {
-            return err
-        }
-        // p will contain regular expression is compatible with regular expression in Perl, Python, and other languages.
-        // for instance the regular expression for path '/articles/{id}' will be '^/articles/(?P<v0>[^/]+)$'
-        p, err := route.GetPathRegexp()
-        if err != nil {
-            return err
-        }
-        // qr will contain a list of regular expressions with the same semantics as GetPathRegexp,
-        // just applied to the Queries pairs instead, e.g., 'Queries("surname", "{surname}") will return
-        // {"^surname=(?P<v0>.*)$}. Where each combined query pair will have an entry in the list.
-        qr, err := route.GetQueriesRegexp()
-        if err != nil {
-            return err
-        }
-        m, err := route.GetMethods()
-        if err != nil {
-            return err
-        }
-        fmt.Println(strings.Join(m, ","), strings.Join(qt, ","), strings.Join(qr, ","), t, p)
-        return nil
-    })
-    http.Handle("/", r)
-}
-```
 
 ### Static Files
 
 Note that the path provided to `PathPrefix()` represents a "wildcard": calling
 `PathPrefix("/static/").Handler(...)` means that the handler will be passed any
-request that matches "/static/*". This makes it easy to serve static files with mux:
+request that matches "/static/\*". This makes it easy to serve static files with mux:
 
 ```go
 func main() {
-	var dir string
+    var dir string
 
-	flag.StringVar(&dir, "dir", ".", "the directory to serve files from. Defaults to the current dir")
-	flag.Parse()
-	r := mux.NewRouter()
+    flag.StringVar(&dir, "dir", ".", "the directory to serve files from. Defaults to the current dir")
+    flag.Parse()
+    r := mux.NewRouter()
 
-	// This will serve files under http://localhost:8000/static/<filename>
-	r.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir(dir))))
+    // This will serve files under http://localhost:8000/static/<filename>
+    r.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir(dir))))
 
-	srv := &http.Server{
-		Handler:      r,
-		Addr:         "127.0.0.1:8000",
-		// Good practice: enforce timeouts for servers you create!
-		WriteTimeout: 15 * time.Second,
-		ReadTimeout:  15 * time.Second,
-	}
+    srv := &http.Server{
+        Handler:      r,
+        Addr:         "127.0.0.1:8000",
+        // Good practice: enforce timeouts for servers you create!
+        WriteTimeout: 15 * time.Second,
+        ReadTimeout:  15 * time.Second,
+    }
 
-	log.Fatal(srv.ListenAndServe())
+    log.Fatal(srv.ListenAndServe())
 }
 ```
 
@@ -346,41 +292,329 @@ The `Walk` function on `mux.Router` can be used to visit all of the routes that 
 the following prints all of the registered routes:
 
 ```go
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	return
+}
+
+func main() {
+	r := mux.NewRouter()
+	r.HandleFunc("/", handler)
+	r.HandleFunc("/products", handler).Methods("POST")
+	r.HandleFunc("/articles", handler).Methods("GET")
+	r.HandleFunc("/articles/{id}", handler).Methods("GET", "PUT")
+	r.HandleFunc("/authors", handler).Queries("surname", "{surname}")
+	err := r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+		pathTemplate, err := route.GetPathTemplate()
+		if err == nil {
+			fmt.Println("ROUTE:", pathTemplate)
+		}
+		pathRegexp, err := route.GetPathRegexp()
+		if err == nil {
+			fmt.Println("Path regexp:", pathRegexp)
+		}
+		queriesTemplates, err := route.GetQueriesTemplates()
+		if err == nil {
+			fmt.Println("Queries templates:", strings.Join(queriesTemplates, ","))
+		}
+		queriesRegexps, err := route.GetQueriesRegexp()
+		if err == nil {
+			fmt.Println("Queries regexps:", strings.Join(queriesRegexps, ","))
+		}
+		methods, err := route.GetMethods()
+		if err == nil {
+			fmt.Println("Methods:", strings.Join(methods, ","))
+		}
+		fmt.Println()
+		return nil
+	})
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	http.Handle("/", r)
+}
+```
+
+### Graceful Shutdown
+
+Go 1.8 introduced the ability to [gracefully shutdown](https://golang.org/doc/go1.8#http_shutdown) a `*http.Server`. Here's how to do that alongside `mux`:
+
+```go
+package main
+
+import (
+    "context"
+    "flag"
+    "log"
+    "net/http"
+    "os"
+    "os/signal"
+    "time"
+
+    "github.com/gorilla/mux"
+)
+
+func main() {
+    var wait time.Duration
+    flag.DurationVar(&wait, "graceful-timeout", time.Second * 15, "the duration for which the server gracefully wait for existing connections to finish - e.g. 15s or 1m")
+    flag.Parse()
+
+    r := mux.NewRouter()
+    // Add your routes as needed
+
+    srv := &http.Server{
+        Addr:         "0.0.0.0:8080",
+        // Good practice to set timeouts to avoid Slowloris attacks.
+        WriteTimeout: time.Second * 15,
+        ReadTimeout:  time.Second * 15,
+        IdleTimeout:  time.Second * 60,
+        Handler: r, // Pass our instance of gorilla/mux in.
+    }
+
+    // Run our server in a goroutine so that it doesn't block.
+    go func() {
+        if err := srv.ListenAndServe(); err != nil {
+            log.Println(err)
+        }
+    }()
+
+    c := make(chan os.Signal, 1)
+    // We'll accept graceful shutdowns when quit via SIGINT (Ctrl+C)
+    // SIGKILL, SIGQUIT or SIGTERM (Ctrl+/) will not be caught.
+    signal.Notify(c, os.Interrupt)
+
+    // Block until we receive our signal.
+    <-c
+
+    // Create a deadline to wait for.
+    ctx, cancel := context.WithTimeout(context.Background(), wait)
+    defer cancel()
+    // Doesn't block if no connections, but will otherwise wait
+    // until the timeout deadline.
+    srv.Shutdown(ctx)
+    // Optionally, you could run srv.Shutdown in a goroutine and block on
+    // <-ctx.Done() if your application should wait for other services
+    // to finalize based on context cancellation.
+    log.Println("shutting down")
+    os.Exit(0)
+}
+```
+
+### Middleware
+
+Mux supports the addition of middlewares to a [Router](https://godoc.org/github.com/gorilla/mux#Router), which are executed in the order they are added if a match is found, including its subrouters.
+Middlewares are (typically) small pieces of code which take one request, do something with it, and pass it down to another middleware or the final handler. Some common use cases for middleware are request logging, header manipulation, or `ResponseWriter` hijacking.
+
+Mux middlewares are defined using the de facto standard type:
+
+```go
+type MiddlewareFunc func(http.Handler) http.Handler
+```
+
+Typically, the returned handler is a closure which does something with the http.ResponseWriter and http.Request passed to it, and then calls the handler passed as parameter to the MiddlewareFunc. This takes advantage of closures being able access variables from the context where they are created, while retaining the signature enforced by the receivers.
+
+A very basic middleware which logs the URI of the request being handled could be written as:
+
+```go
+func loggingMiddleware(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        // Do stuff here
+        log.Println(r.RequestURI)
+        // Call the next handler, which can be another middleware in the chain, or the final handler.
+        next.ServeHTTP(w, r)
+    })
+}
+```
+
+Middlewares can be added to a router using `Router.Use()`:
+
+```go
 r := mux.NewRouter()
 r.HandleFunc("/", handler)
-r.HandleFunc("/products", handler).Methods("POST")
-r.HandleFunc("/articles", handler).Methods("GET")
-r.HandleFunc("/articles/{id}", handler).Methods("GET", "PUT")
-r.HandleFunc("/authors", handler).Queries("surname", "{surname}")
-r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
-    t, err := route.GetPathTemplate()
+r.Use(loggingMiddleware)
+```
+
+A more complex authentication middleware, which maps session token to users, could be written as:
+
+```go
+// Define our struct
+type authenticationMiddleware struct {
+	tokenUsers map[string]string
+}
+
+// Initialize it somewhere
+func (amw *authenticationMiddleware) Populate() {
+	amw.tokenUsers["00000000"] = "user0"
+	amw.tokenUsers["aaaaaaaa"] = "userA"
+	amw.tokenUsers["05f717e5"] = "randomUser"
+	amw.tokenUsers["deadbeef"] = "user0"
+}
+
+// Middleware function, which will be called for each request
+func (amw *authenticationMiddleware) Middleware(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        token := r.Header.Get("X-Session-Token")
+
+        if user, found := amw.tokenUsers[token]; found {
+        	// We found the token in our map
+        	log.Printf("Authenticated user %s\n", user)
+        	// Pass down the request to the next middleware (or final handler)
+        	next.ServeHTTP(w, r)
+        } else {
+        	// Write an error and stop the handler chain
+        	http.Error(w, "Forbidden", http.StatusForbidden)
+        }
+    })
+}
+```
+
+```go
+r := mux.NewRouter()
+r.HandleFunc("/", handler)
+
+amw := authenticationMiddleware{}
+amw.Populate()
+
+r.Use(amw.Middleware)
+```
+
+Note: The handler chain will be stopped if your middleware doesn't call `next.ServeHTTP()` with the corresponding parameters. This can be used to abort a request if the middleware writer wants to. Middlewares _should_ write to `ResponseWriter` if they _are_ going to terminate the request, and they _should not_ write to `ResponseWriter` if they _are not_ going to terminate it.
+
+### Testing Handlers
+
+Testing handlers in a Go web application is straightforward, and _mux_ doesn't complicate this any further. Given two files: `endpoints.go` and `endpoints_test.go`, here's how we'd test an application using _mux_.
+
+First, our simple HTTP handler:
+
+```go
+// endpoints.go
+package main
+
+func HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
+    // A very simple health check.
+    w.WriteHeader(http.StatusOK)
+    w.Header().Set("Content-Type", "application/json")
+
+    // In the future we could report back on the status of our DB, or our cache
+    // (e.g. Redis) by performing a simple PING, and include them in the response.
+    io.WriteString(w, `{"alive": true}`)
+}
+
+func main() {
+    r := mux.NewRouter()
+    r.HandleFunc("/health", HealthCheckHandler)
+
+    log.Fatal(http.ListenAndServe("localhost:8080", r))
+}
+```
+
+Our test code:
+
+```go
+// endpoints_test.go
+package main
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "testing"
+)
+
+func TestHealthCheckHandler(t *testing.T) {
+    // Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+    // pass 'nil' as the third parameter.
+    req, err := http.NewRequest("GET", "/health", nil)
     if err != nil {
-        return err
+        t.Fatal(err)
     }
-    qt, err := route.GetQueriesTemplates()
-    if err != nil {
-        return err
+
+    // We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+    rr := httptest.NewRecorder()
+    handler := http.HandlerFunc(HealthCheckHandler)
+
+    // Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+    // directly and pass in our Request and ResponseRecorder.
+    handler.ServeHTTP(rr, req)
+
+    // Check the status code is what we expect.
+    if status := rr.Code; status != http.StatusOK {
+        t.Errorf("handler returned wrong status code: got %v want %v",
+            status, http.StatusOK)
     }
-    // p will contain a regular expression that is compatible with regular expressions in Perl, Python, and other languages.
-    // For example, the regular expression for path '/articles/{id}' will be '^/articles/(?P<v0>[^/]+)$'.
-    p, err := route.GetPathRegexp()
-    if err != nil {
-        return err
+
+    // Check the response body is what we expect.
+    expected := `{"alive": true}`
+    if rr.Body.String() != expected {
+        t.Errorf("handler returned unexpected body: got %v want %v",
+            rr.Body.String(), expected)
     }
-    // qr will contain a list of regular expressions with the same semantics as GetPathRegexp,
-    // just applied to the Queries pairs instead, e.g., 'Queries("surname", "{surname}") will return
-    // {"^surname=(?P<v0>.*)$}. Where each combined query pair will have an entry in the list.
-    qr, err := route.GetQueriesRegexp()
-    if err != nil {
-        return err
+}
+```
+
+In the case that our routes have [variables](#examples), we can pass those in the request. We could write
+[table-driven tests](https://dave.cheney.net/2013/06/09/writing-table-driven-tests-in-go) to test multiple
+possible route variables as needed.
+
+```go
+// endpoints.go
+func main() {
+    r := mux.NewRouter()
+    // A route with a route variable:
+    r.HandleFunc("/metrics/{type}", MetricsHandler)
+
+    log.Fatal(http.ListenAndServe("localhost:8080", r))
+}
+```
+
+Our test file, with a table-driven test of `routeVariables`:
+
+```go
+// endpoints_test.go
+func TestMetricsHandler(t *testing.T) {
+    tt := []struct{
+        routeVariable string
+        shouldPass bool
+    }{
+        {"goroutines", true},
+        {"heap", true},
+        {"counters", true},
+        {"queries", true},
+        {"adhadaeqm3k", false},
     }
-    m, err := route.GetMethods()
-    if err != nil {
-        return err
+
+    for _, tc := range tt {
+        path := fmt.Sprintf("/metrics/%s", tc.routeVariable)
+        req, err := http.NewRequest("GET", path, nil)
+        if err != nil {
+            t.Fatal(err)
+        }
+
+        rr := httptest.NewRecorder()
+	
+	// Need to create a router that we can pass the request through so that the vars will be added to the context
+	router := mux.NewRouter()
+        router.HandleFunc("/metrics/{type}", MetricsHandler)
+        router.ServeHTTP(rr, req)
+
+        // In this case, our MetricsHandler returns a non-200 response
+        // for a route variable it doesn't know about.
+        if rr.Code == http.StatusOK && !tc.shouldPass {
+            t.Errorf("handler should have failed on routeVariable %s: got %v want %v",
+                tc.routeVariable, rr.Code, http.StatusOK)
+        }
     }
-    fmt.Println(strings.Join(m, ","), strings.Join(qt, ","), strings.Join(qr, ","), t, p)
-    return nil
-})
+}
 ```
 
 ## Full Example
@@ -391,22 +625,22 @@ Here's a complete, runnable example of a small `mux` based server:
 package main
 
 import (
-	"net/http"
-	"log"
-	"github.com/gorilla/mux"
+    "net/http"
+    "log"
+    "github.com/gorilla/mux"
 )
 
 func YourHandler(w http.ResponseWriter, r *http.Request) {
-	w.Write([]byte("Gorilla!\n"))
+    w.Write([]byte("Gorilla!\n"))
 }
 
 func main() {
-	r := mux.NewRouter()
-	// Routes consist of a path and a handler function.
-	r.HandleFunc("/", YourHandler)
+    r := mux.NewRouter()
+    // Routes consist of a path and a handler function.
+    r.HandleFunc("/", YourHandler)
 
-	// Bind to a port and pass our router in
-	log.Fatal(http.ListenAndServe(":8000", r))
+    // Bind to a port and pass our router in
+    log.Fatal(http.ListenAndServe(":8000", r))
 }
 ```
 

--- a/vendor/github.com/gorilla/mux/doc.go
+++ b/vendor/github.com/gorilla/mux/doc.go
@@ -238,5 +238,69 @@ as well:
 	url, err := r.Get("article").URL("subdomain", "news",
 	                                 "category", "technology",
 	                                 "id", "42")
+
+Mux supports the addition of middlewares to a Router, which are executed in the order they are added if a match is found, including its subrouters. Middlewares are (typically) small pieces of code which take one request, do something with it, and pass it down to another middleware or the final handler. Some common use cases for middleware are request logging, header manipulation, or ResponseWriter hijacking.
+
+	type MiddlewareFunc func(http.Handler) http.Handler
+
+Typically, the returned handler is a closure which does something with the http.ResponseWriter and http.Request passed to it, and then calls the handler passed as parameter to the MiddlewareFunc (closures can access variables from the context where they are created).
+
+A very basic middleware which logs the URI of the request being handled could be written as:
+
+	func simpleMw(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Do stuff here
+			log.Println(r.RequestURI)
+			// Call the next handler, which can be another middleware in the chain, or the final handler.
+			next.ServeHTTP(w, r)
+		})
+	}
+
+Middlewares can be added to a router using `Router.Use()`:
+
+	r := mux.NewRouter()
+	r.HandleFunc("/", handler)
+	r.Use(simpleMw)
+
+A more complex authentication middleware, which maps session token to users, could be written as:
+
+	// Define our struct
+	type authenticationMiddleware struct {
+		tokenUsers map[string]string
+	}
+
+	// Initialize it somewhere
+	func (amw *authenticationMiddleware) Populate() {
+		amw.tokenUsers["00000000"] = "user0"
+		amw.tokenUsers["aaaaaaaa"] = "userA"
+		amw.tokenUsers["05f717e5"] = "randomUser"
+		amw.tokenUsers["deadbeef"] = "user0"
+	}
+
+	// Middleware function, which will be called for each request
+	func (amw *authenticationMiddleware) Middleware(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token := r.Header.Get("X-Session-Token")
+
+			if user, found := amw.tokenUsers[token]; found {
+				// We found the token in our map
+				log.Printf("Authenticated user %s\n", user)
+				next.ServeHTTP(w, r)
+			} else {
+				http.Error(w, "Forbidden", http.StatusForbidden)
+			}
+		})
+	}
+
+	r := mux.NewRouter()
+	r.HandleFunc("/", handler)
+
+	amw := authenticationMiddleware{}
+	amw.Populate()
+
+	r.Use(amw.Middleware)
+
+Note: The handler chain will be stopped if your middleware doesn't call `next.ServeHTTP()` with the corresponding parameters. This can be used to abort a request if the middleware writer wants to.
+
 */
 package mux

--- a/vendor/github.com/gorilla/mux/middleware.go
+++ b/vendor/github.com/gorilla/mux/middleware.go
@@ -1,0 +1,72 @@
+package mux
+
+import (
+	"net/http"
+	"strings"
+)
+
+// MiddlewareFunc is a function which receives an http.Handler and returns another http.Handler.
+// Typically, the returned handler is a closure which does something with the http.ResponseWriter and http.Request passed
+// to it, and then calls the handler passed as parameter to the MiddlewareFunc.
+type MiddlewareFunc func(http.Handler) http.Handler
+
+// middleware interface is anything which implements a MiddlewareFunc named Middleware.
+type middleware interface {
+	Middleware(handler http.Handler) http.Handler
+}
+
+// Middleware allows MiddlewareFunc to implement the middleware interface.
+func (mw MiddlewareFunc) Middleware(handler http.Handler) http.Handler {
+	return mw(handler)
+}
+
+// Use appends a MiddlewareFunc to the chain. Middleware can be used to intercept or otherwise modify requests and/or responses, and are executed in the order that they are applied to the Router.
+func (r *Router) Use(mwf ...MiddlewareFunc) {
+	for _, fn := range mwf {
+		r.middlewares = append(r.middlewares, fn)
+	}
+}
+
+// useInterface appends a middleware to the chain. Middleware can be used to intercept or otherwise modify requests and/or responses, and are executed in the order that they are applied to the Router.
+func (r *Router) useInterface(mw middleware) {
+	r.middlewares = append(r.middlewares, mw)
+}
+
+// CORSMethodMiddleware sets the Access-Control-Allow-Methods response header
+// on a request, by matching routes based only on paths. It also handles
+// OPTIONS requests, by settings Access-Control-Allow-Methods, and then
+// returning without calling the next http handler.
+func CORSMethodMiddleware(r *Router) MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			var allMethods []string
+
+			err := r.Walk(func(route *Route, _ *Router, _ []*Route) error {
+				for _, m := range route.matchers {
+					if _, ok := m.(*routeRegexp); ok {
+						if m.Match(req, &RouteMatch{}) {
+							methods, err := route.GetMethods()
+							if err != nil {
+								return err
+							}
+
+							allMethods = append(allMethods, methods...)
+						}
+						break
+					}
+				}
+				return nil
+			})
+
+			if err == nil {
+				w.Header().Set("Access-Control-Allow-Methods", strings.Join(append(allMethods, "OPTIONS"), ","))
+
+				if req.Method == "OPTIONS" {
+					return
+				}
+			}
+
+			next.ServeHTTP(w, req)
+		})
+	}
+}

--- a/vendor/github.com/gorilla/mux/regexp.go
+++ b/vendor/github.com/gorilla/mux/regexp.go
@@ -14,6 +14,20 @@ import (
 	"strings"
 )
 
+type routeRegexpOptions struct {
+	strictSlash    bool
+	useEncodedPath bool
+}
+
+type regexpType int
+
+const (
+	regexpTypePath   regexpType = 0
+	regexpTypeHost   regexpType = 1
+	regexpTypePrefix regexpType = 2
+	regexpTypeQuery  regexpType = 3
+)
+
 // newRouteRegexp parses a route template and returns a routeRegexp,
 // used to match a host, a path or a query string.
 //
@@ -24,7 +38,7 @@ import (
 // Previously we accepted only Python-like identifiers for variable
 // names ([a-zA-Z_][a-zA-Z0-9_]*), but currently the only restriction is that
 // name and pattern can't be empty, and names can't contain a colon.
-func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash, useEncodedPath bool) (*routeRegexp, error) {
+func newRouteRegexp(tpl string, typ regexpType, options routeRegexpOptions) (*routeRegexp, error) {
 	// Check if it is well-formed.
 	idxs, errBraces := braceIndices(tpl)
 	if errBraces != nil {
@@ -34,19 +48,18 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash,
 	template := tpl
 	// Now let's parse it.
 	defaultPattern := "[^/]+"
-	if matchQuery {
+	if typ == regexpTypeQuery {
 		defaultPattern = ".*"
-	} else if matchHost {
+	} else if typ == regexpTypeHost {
 		defaultPattern = "[^.]+"
-		matchPrefix = false
 	}
 	// Only match strict slash if not matching
-	if matchPrefix || matchHost || matchQuery {
-		strictSlash = false
+	if typ != regexpTypePath {
+		options.strictSlash = false
 	}
 	// Set a flag for strictSlash.
 	endSlash := false
-	if strictSlash && strings.HasSuffix(tpl, "/") {
+	if options.strictSlash && strings.HasSuffix(tpl, "/") {
 		tpl = tpl[:len(tpl)-1]
 		endSlash = true
 	}
@@ -88,16 +101,16 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash,
 	// Add the remaining.
 	raw := tpl[end:]
 	pattern.WriteString(regexp.QuoteMeta(raw))
-	if strictSlash {
+	if options.strictSlash {
 		pattern.WriteString("[/]?")
 	}
-	if matchQuery {
+	if typ == regexpTypeQuery {
 		// Add the default pattern if the query value is empty
 		if queryVal := strings.SplitN(template, "=", 2)[1]; queryVal == "" {
 			pattern.WriteString(defaultPattern)
 		}
 	}
-	if !matchPrefix {
+	if typ != regexpTypePrefix {
 		pattern.WriteByte('$')
 	}
 	reverse.WriteString(raw)
@@ -118,15 +131,13 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash,
 
 	// Done!
 	return &routeRegexp{
-		template:       template,
-		matchHost:      matchHost,
-		matchQuery:     matchQuery,
-		strictSlash:    strictSlash,
-		useEncodedPath: useEncodedPath,
-		regexp:         reg,
-		reverse:        reverse.String(),
-		varsN:          varsN,
-		varsR:          varsR,
+		template:   template,
+		regexpType: typ,
+		options:    options,
+		regexp:     reg,
+		reverse:    reverse.String(),
+		varsN:      varsN,
+		varsR:      varsR,
 	}, nil
 }
 
@@ -135,15 +146,10 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash,
 type routeRegexp struct {
 	// The unmodified template.
 	template string
-	// True for host match, false for path or query string match.
-	matchHost bool
-	// True for query string match, false for path and host match.
-	matchQuery bool
-	// The strictSlash value defined on the route, but disabled if PathPrefix was used.
-	strictSlash bool
-	// Determines whether to use encoded req.URL.EnscapedPath() or unencoded
-	// req.URL.Path for path matching
-	useEncodedPath bool
+	// The type of match
+	regexpType regexpType
+	// Options for matching
+	options routeRegexpOptions
 	// Expanded regexp.
 	regexp *regexp.Regexp
 	// Reverse template.
@@ -156,12 +162,12 @@ type routeRegexp struct {
 
 // Match matches the regexp against the URL host or path.
 func (r *routeRegexp) Match(req *http.Request, match *RouteMatch) bool {
-	if !r.matchHost {
-		if r.matchQuery {
+	if r.regexpType != regexpTypeHost {
+		if r.regexpType == regexpTypeQuery {
 			return r.matchQueryString(req)
 		}
 		path := req.URL.Path
-		if r.useEncodedPath {
+		if r.options.useEncodedPath {
 			path = req.URL.EscapedPath()
 		}
 		return r.regexp.MatchString(path)
@@ -178,7 +184,7 @@ func (r *routeRegexp) url(values map[string]string) (string, error) {
 		if !ok {
 			return "", fmt.Errorf("mux: missing route variable %q", v)
 		}
-		if r.matchQuery {
+		if r.regexpType == regexpTypeQuery {
 			value = url.QueryEscape(value)
 		}
 		urlValues[k] = value
@@ -203,7 +209,7 @@ func (r *routeRegexp) url(values map[string]string) (string, error) {
 // For a URL with foo=bar&baz=ding, we return only the relevant key
 // value pair for the routeRegexp.
 func (r *routeRegexp) getURLQuery(req *http.Request) string {
-	if !r.matchQuery {
+	if r.regexpType != regexpTypeQuery {
 		return ""
 	}
 	templateKey := strings.SplitN(r.template, "=", 2)[0]
@@ -280,7 +286,7 @@ func (v *routeRegexpGroup) setMatch(req *http.Request, m *RouteMatch, r *Route) 
 		if len(matches) > 0 {
 			extractVars(path, matches, v.path.varsN, m.Vars)
 			// Check if we should redirect.
-			if v.path.strictSlash {
+			if v.path.options.strictSlash {
 				p1 := strings.HasSuffix(path, "/")
 				p2 := strings.HasSuffix(v.path.template, "/")
 				if p1 != p2 {

--- a/vendor/github.com/gorilla/mux/test_helpers.go
+++ b/vendor/github.com/gorilla/mux/test_helpers.go
@@ -1,0 +1,19 @@
+// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mux
+
+import "net/http"
+
+// SetURLVars sets the URL variables for the given request, to be accessed via
+// mux.Vars for testing route behaviour. Arguments are not modified, a shallow
+// copy is returned.
+//
+// This API should only be used for testing purposes; it provides a way to
+// inject variables into the request context. Alternatively, URL variables
+// can be set by making a route that captures the required variables,
+// starting a server and sending the request to that server.
+func SetURLVars(r *http.Request, val map[string]string) *http.Request {
+	return setVars(r, val)
+}


### PR DESCRIPTION
This addresses #9 by creating a standard Proxy handler and updating the provider config to accept a resolver method that is then provided by the provider implementation. This ensures that the proxy logic is consistent between the various providers while allowing them to customize the function lookup implementation details. 

This also implements the sub-path routing to functions.   Unit tests from the `gateway` implementation have been ported here as well. 

Please note that this includes an update to the Gorilla Mux package.  This upgrade primarily makes testing easier by introducing the `SetURLVars` method. 