### PR TITLE
Return upstream status code instead of 200

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -129,7 +129,9 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 		writeError(w, http.StatusInternalServerError, "Failed to resolve service: %s.", functionName)
 		return
 	}
-	defer proxyReq.Body.Close()
+	if proxyReq.Body != nil {
+		defer proxyReq.Body.Close()
+	}
 
 	start := time.Now()
 	response, err := proxyClient.Do(proxyReq.WithContext(ctx))
@@ -148,7 +150,7 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 	copyHeaders(clientHeader, &response.Header)
 	w.Header().Set("Content-Type", getContentType(response.Header, originalReq.Header))
 
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(response.StatusCode)
 	io.Copy(w, response.Body)
 }
 


### PR DESCRIPTION
**What**
- Instead of returning a fixed 200 status code, we will not return the
upstream status code.  This allows better control for the function
author and can ease debugging.
- A test has been added to verify the proxy handler will always return
the upstream code

Resolves #18 

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>