### PR TITLE
Add support for Multiple Users in Basic Auth

### DIFF
--- a/auth/basic_auth.go
+++ b/auth/basic_auth.go
@@ -15,12 +15,39 @@ func DecorateWithBasicAuth(next http.HandlerFunc, credentials *BasicAuthCredenti
 		w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
 
 		if !ok || !(credentials.Password == password && user == credentials.User) {
-
-			w.WriteHeader(http.StatusUnauthorized)
-			w.Write([]byte("invalid credentials"))
-			return
+			unauthorized(w, r)
 		}
 
 		next.ServeHTTP(w, r)
 	}
+}
+
+// Support for Multiple User Basic Auth Providers
+func DecorateWithMultiUserBasicAuth(next http.HandlerFunc, creds []BasicAuthCredentials) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		ok := false
+		user, password, _ := r.BasicAuth()
+		w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+
+		for _, v := range creds {
+			if v.User == user && v.Password == password {
+				ok = true
+				break
+			}
+		}
+
+		if !ok {
+			unauthorized(w, r)
+		}
+
+		next.ServeHTTP(w, r)
+	}
+}
+
+// Helper function to return a 401
+func unauthorized(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusUnauthorized)
+	w.Write([]byte("invalid credentials"))
+	return
 }

--- a/auth/basic_auth_test.go
+++ b/auth/basic_auth_test.go
@@ -64,3 +64,92 @@ func Test_AuthWithInvalidPassword_Gives403(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func Test_MultiUserAuthWithValidPassword_Gives200(t *testing.T) {
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "<html><body>Hello World!</body></html>")
+	}
+	w := httptest.NewRecorder()
+
+	wantUser := "admin"
+	wantPassword := "password"
+	r := httptest.NewRequest(http.MethodGet, "http://localhost:8080", nil)
+	r.SetBasicAuth(wantUser, wantPassword)
+	wantCredentials := getMultiUserAuthCreds()
+
+	decorated := DecorateWithMultiUserBasicAuth(handler, wantCredentials)
+	decorated.ServeHTTP(w, r)
+
+	wantCode := http.StatusOK
+
+	if w.Code != wantCode {
+		t.Errorf("status code, want: %d, got: %d", wantCode, w.Code)
+		t.Fail()
+	}
+}
+
+func Test_MultiUserAuthWithInvalidPassword_Gives401(t *testing.T) {
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "<html><body>Hello World!</body></html>")
+	}
+	w := httptest.NewRecorder()
+
+	wantUser := "admin"
+	wantPassword := "apassword"
+	r := httptest.NewRequest(http.MethodGet, "http://localhost:8080", nil)
+	r.SetBasicAuth(wantUser, wantPassword)
+	wantCredentials := getMultiUserAuthCreds()
+
+	decorated := DecorateWithMultiUserBasicAuth(handler, wantCredentials)
+	decorated.ServeHTTP(w, r)
+
+	wantCode := http.StatusUnauthorized
+
+	if w.Code != wantCode {
+		t.Errorf("status code, want: %d, got: %d", wantCode, w.Code)
+		t.Fail()
+	}
+}
+
+func Test_MultiUserAuthWithInvalidUser_Gives401(t *testing.T) {
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "<html><body>Hello World!</body></html>")
+	}
+	w := httptest.NewRecorder()
+
+	wantUser := "affix"
+	wantPassword := "apassword"
+	r := httptest.NewRequest(http.MethodGet, "http://localhost:8080", nil)
+	r.SetBasicAuth(wantUser, wantPassword)
+	wantCredentials := getMultiUserAuthCreds()
+
+	decorated := DecorateWithMultiUserBasicAuth(handler, wantCredentials)
+	decorated.ServeHTTP(w, r)
+
+	wantCode := http.StatusUnauthorized
+
+	if w.Code != wantCode {
+		t.Errorf("status code, want: %d, got: %d", wantCode, w.Code)
+		t.Fail()
+	}
+}
+
+func getMultiUserAuthCreds() []BasicAuthCredentials {
+	return []BasicAuthCredentials{
+		{
+			User:     "admin",
+			Password: "password",
+		},
+		{
+			User:     "auser",
+			Password: "apassword",
+		},
+		{
+			User:     "someoneelse",
+			Password: "anotherpass",
+		},
+	}
+}


### PR DESCRIPTION
Adds support for Multiple Users in the Basic Auth provider

required by : https://github.com/openfaas/faas/issues/1215

Signed-off-by: Keiran Smith <contact@keiran.scot>