### PR TITLE
Fix import of httputils and add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+go_import_path: github.com/openfaas/faas-provider
+script:
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,6 @@
 build:
 	docker build -t faas-provider .
+
+
+test :
+	go test -cover ./...

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/openfaas/faas-provider/httputils"
+	"github.com/openfaas/faas-provider/httputil"
 )
 
 const (
@@ -112,7 +112,7 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 	pathVars := mux.Vars(originalReq)
 	functionName := pathVars["name"]
 	if functionName == "" {
-		httputils.Errorf(w, http.StatusBadRequest, errMissingFunctionName)
+		httputil.Errorf(w, http.StatusBadRequest, errMissingFunctionName)
 		return
 	}
 
@@ -120,13 +120,13 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 	if resolveErr != nil {
 		// TODO: Should record the 404/not found error in Prometheus.
 		log.Printf("resolver error: cannot find %s: %s\n", functionName, resolveErr.Error())
-		httputils.Errorf(w, http.StatusNotFound, "Cannot find service: %s.", functionName)
+		httputil.Errorf(w, http.StatusNotFound, "Cannot find service: %s.", functionName)
 		return
 	}
 
 	proxyReq, err := buildProxyRequest(originalReq, functionAddr, pathVars["params"])
 	if err != nil {
-		httputils.Errorf(w, http.StatusInternalServerError, "Failed to resolve service: %s.", functionName)
+		httputil.Errorf(w, http.StatusInternalServerError, "Failed to resolve service: %s.", functionName)
 		return
 	}
 	if proxyReq.Body != nil {
@@ -140,7 +140,7 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 	if err != nil {
 		log.Printf("error with proxy request to: %s, %s\n", proxyReq.URL.String(), err.Error())
 
-		httputils.Errorf(w, http.StatusInternalServerError, "Can't reach service for: %s.", functionName)
+		httputil.Errorf(w, http.StatusInternalServerError, "Can't reach service for: %s.", functionName)
 		return
 	}
 


### PR DESCRIPTION
**What**
- Fix a broken rename in the `proxy` pkg, it was referencing `httputils`
instead of the correct `httputil`
- Add a travis config to help ensure that the project is compilable
- Add a `make test` target to make it easy for contributors to run tests before submitting changes

In totally, this should make submissions to `faas-provider` much more reliable because testing will be easier and automated.  

Resolves #23 