### PR TITLE
Add /system/namespaces endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.10.4-alpine3.8
+FROM golang:1.11-alpine3.10
+
+ENV CGO_ENABLED=0
 
 RUN mkdir -p /go/src/github.com/openfaas/faas-provider/
 

--- a/serve.go
+++ b/serve.go
@@ -65,6 +65,8 @@ func Serve(handlers *types.FaaSHandlers, config *types.FaaSConfig) {
 	r.HandleFunc("/system/secrets", handlers.SecretHandler).Methods(http.MethodGet, http.MethodPut, http.MethodPost, http.MethodDelete)
 	r.HandleFunc("/system/logs", handlers.LogHandler).Methods(http.MethodGet)
 
+	r.HandleFunc("/system/namespaces", handlers.ListNamespaceHandler).Methods("GET")
+
 	// Open endpoints
 	r.HandleFunc("/function/{name:["+NameExpression+"]+}", handlers.FunctionProxy)
 	r.HandleFunc("/function/{name:["+NameExpression+"]+}/", handlers.FunctionProxy)

--- a/types/config.go
+++ b/types/config.go
@@ -7,11 +7,13 @@ import (
 
 // FaaSHandlers provide handlers for OpenFaaS
 type FaaSHandlers struct {
-	FunctionReader http.HandlerFunc
-	DeployHandler  http.HandlerFunc
 	// FunctionProxy provides the function invocation proxy logic.  Use proxy.NewHandlerFunc to
 	// use the standard OpenFaaS proxy implementation or provide completely custom proxy logic.
-	FunctionProxy  http.HandlerFunc
+	FunctionProxy http.HandlerFunc
+
+	FunctionReader http.HandlerFunc
+	DeployHandler  http.HandlerFunc
+
 	DeleteHandler  http.HandlerFunc
 	ReplicaReader  http.HandlerFunc
 	ReplicaUpdater http.HandlerFunc
@@ -19,10 +21,11 @@ type FaaSHandlers struct {
 	// LogHandler provides streaming json logs of functions
 	LogHandler http.HandlerFunc
 
-	// Optional: Update an existing function
-	UpdateHandler http.HandlerFunc
-	HealthHandler http.HandlerFunc
-	InfoHandler   http.HandlerFunc
+	// UpdateHandler an existing function/service
+	UpdateHandler        http.HandlerFunc
+	HealthHandler        http.HandlerFunc
+	InfoHandler          http.HandlerFunc
+	ListNamespaceHandler http.HandlerFunc
 }
 
 // FaaSConfig set config for HTTP handlers


### PR DESCRIPTION
Add /system/namespaces endpoint
    
This is being added to enable the UI/CLI to list valid
OpenFaaS function namespaces before then sending the namespace
as a query to other endpoints.
