### PR TITLE
Update ReadBasicAuth interface signature

### DIFF
--- a/auth/credentials.go
+++ b/auth/credentials.go
@@ -17,7 +17,7 @@ type BasicAuthCredentials struct {
 }
 
 type ReadBasicAuth interface {
-	Read() (error, *BasicAuthCredentials)
+	Read() (*BasicAuthCredentials, error)
 }
 
 type ReadBasicAuthFromDisk struct {


### PR DESCRIPTION
Even though `ReadBasicAuth` is not used yet in the code, it looks like `BasicAuthCredentials` is supposed to satisfy it with the `Read()` method. However, the signatures differ in that the interface returns the `error` first instead of `*BasicAuthCredentials`. This could cause bugs in the future when using the interface and also is not considered idiomatic Go code.