### PR TITLE
Ensure that the proxy requst respone body is closed

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -143,6 +143,7 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 		httputil.Errorf(w, http.StatusInternalServerError, "Can't reach service for: %s.", functionName)
 		return
 	}
+	defer response.Body.Close()
 
 	log.Printf("%s took %f seconds\n", functionName, seconds.Seconds())
 


### PR DESCRIPTION
**What**
- Ensure that we defer a Close on the response body so that we do not
leak the memory or the connection

Resolves https://github.com/openfaas/faas-netes/pull/532/files/3013e4bd13f81a8d201a0358281e347504f0aa2d#r332534103

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>