### PR TITLE
Compare basic-auth with constant time

### DIFF
--- a/auth/basic_auth_test.go
+++ b/auth/basic_auth_test.go
@@ -20,6 +20,7 @@ func Test_AuthWithValidPassword_Gives200(t *testing.T) {
 	wantUser := "admin"
 	wantPassword := "password"
 	r := httptest.NewRequest(http.MethodGet, "http://localhost:8080", nil)
+
 	r.SetBasicAuth(wantUser, wantPassword)
 	wantCredentials := &BasicAuthCredentials{
 		User:     wantUser,
@@ -33,6 +34,13 @@ func Test_AuthWithValidPassword_Gives200(t *testing.T) {
 
 	if w.Code != wantCode {
 		t.Errorf("status code, want: %d, got: %d", wantCode, w.Code)
+		t.Fail()
+	}
+
+	gotAuth := w.Header().Get("WWW-Authenticate")
+	wantAuth := ``
+	if gotAuth != wantAuth {
+		t.Errorf("WWW-Authenticate, want: %s, got: %s", wantAuth, gotAuth)
 		t.Fail()
 	}
 }
@@ -61,6 +69,13 @@ func Test_AuthWithInvalidPassword_Gives403(t *testing.T) {
 	wantCode := http.StatusUnauthorized
 	if w.Code != wantCode {
 		t.Errorf("status code, want: %d, got: %d", wantCode, w.Code)
+		t.Fail()
+	}
+
+	gotAuth := w.Header().Get("WWW-Authenticate")
+	wantAuth := `Basic realm="Restricted"`
+	if gotAuth != wantAuth {
+		t.Errorf("WWW-Authenticate, want: %s, got: %s", wantAuth, gotAuth)
 		t.Fail()
 	}
 }


### PR DESCRIPTION
A third-party security audit of Kubernetes found this issue
in the way they validated basic auth credentials. This change
implements the same check for the basic-auth plugin.

https://github.com/kubernetes/kubernetes/pull/81152

Other plugins are also available such as OAuth2 / OIDC for
the OpenFaaS gateway.

The WWW-Authenticate realm was being set even when auth passed,
this was unnecessary and has been configured to only be set
when auth is required or the header is missing.

Tested with additional unit tests.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>