### PR TITLE
Update proxy client default config

### DIFF
--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -37,7 +37,7 @@ func Test_NewHandlerFunc_Panic(t *testing.T) {
 		}
 	}()
 
-	config := types.FaaSConfig{ReadTimeout: time.Second}
+	config := types.FaaSConfig{ReadTimeout: 100 * time.Millisecond}
 	NewHandlerFunc(config, nil)
 }
 
@@ -48,7 +48,7 @@ func Test_NewHandlerFunc_NoPanic(t *testing.T) {
 		}
 	}()
 
-	config := types.FaaSConfig{ReadTimeout: time.Second}
+	config := types.FaaSConfig{ReadTimeout: 100 * time.Millisecond}
 	proxyFunc := NewHandlerFunc(config, &testBaseURLResolver{})
 	if proxyFunc == nil {
 		t.Errorf("proxy handler func is nil")
@@ -56,7 +56,7 @@ func Test_NewHandlerFunc_NoPanic(t *testing.T) {
 }
 
 func Test_ProxyHandler_NonAllowedMethods(t *testing.T) {
-	config := types.FaaSConfig{ReadTimeout: time.Second}
+	config := types.FaaSConfig{ReadTimeout: 100 * time.Millisecond}
 	proxyFunc := NewHandlerFunc(config, &testBaseURLResolver{})
 
 	nonAllowedMethods := []string{
@@ -77,7 +77,7 @@ func Test_ProxyHandler_NonAllowedMethods(t *testing.T) {
 }
 
 func Test_ProxyHandler_MissingFunctionNameError(t *testing.T) {
-	config := types.FaaSConfig{ReadTimeout: time.Second}
+	config := types.FaaSConfig{ReadTimeout: 100 * time.Millisecond}
 	proxyFunc := NewHandlerFunc(config, &testBaseURLResolver{"", nil})
 
 	w := httptest.NewRecorder()
@@ -102,7 +102,7 @@ func Test_ProxyHandler_ResolveError(t *testing.T) {
 
 	resolveErr := errors.New("can not find test service `foo`")
 
-	config := types.FaaSConfig{ReadTimeout: time.Second}
+	config := types.FaaSConfig{ReadTimeout: 100 * time.Millisecond}
 	proxyFunc := NewHandlerFunc(config, &testBaseURLResolver{"", resolveErr})
 
 	w := httptest.NewRecorder()

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/openfaas/faas-provider/types"
 )
 
 type testBaseURLResolver struct {
@@ -36,7 +37,8 @@ func Test_NewHandlerFunc_Panic(t *testing.T) {
 		}
 	}()
 
-	NewHandlerFunc(time.Second, nil)
+	config := types.FaaSConfig{ReadTimeout: time.Second}
+	NewHandlerFunc(config, nil)
 }
 
 func Test_NewHandlerFunc_NoPanic(t *testing.T) {
@@ -46,15 +48,16 @@ func Test_NewHandlerFunc_NoPanic(t *testing.T) {
 		}
 	}()
 
-	proxyFunc := NewHandlerFunc(time.Second, &testBaseURLResolver{})
+	config := types.FaaSConfig{ReadTimeout: time.Second}
+	proxyFunc := NewHandlerFunc(config, &testBaseURLResolver{})
 	if proxyFunc == nil {
 		t.Errorf("proxy handler func is nil")
 	}
 }
 
 func Test_ProxyHandler_NonAllowedMethods(t *testing.T) {
-
-	proxyFunc := NewHandlerFunc(time.Second, &testBaseURLResolver{})
+	config := types.FaaSConfig{ReadTimeout: time.Second}
+	proxyFunc := NewHandlerFunc(config, &testBaseURLResolver{})
 
 	nonAllowedMethods := []string{
 		http.MethodHead, http.MethodConnect, http.MethodOptions, http.MethodTrace,
@@ -74,7 +77,8 @@ func Test_ProxyHandler_NonAllowedMethods(t *testing.T) {
 }
 
 func Test_ProxyHandler_MissingFunctionNameError(t *testing.T) {
-	proxyFunc := NewHandlerFunc(time.Second, &testBaseURLResolver{"", nil})
+	config := types.FaaSConfig{ReadTimeout: time.Second}
+	proxyFunc := NewHandlerFunc(config, &testBaseURLResolver{"", nil})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
@@ -97,7 +101,9 @@ func Test_ProxyHandler_ResolveError(t *testing.T) {
 	log.SetOutput(logs)
 
 	resolveErr := errors.New("can not find test service `foo`")
-	proxyFunc := NewHandlerFunc(time.Second, &testBaseURLResolver{"", resolveErr})
+
+	config := types.FaaSConfig{ReadTimeout: time.Second}
+	proxyFunc := NewHandlerFunc(config, &testBaseURLResolver{"", resolveErr})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -88,22 +88,7 @@ func NewHandlerFunc(config types.FaaSConfig, resolver BaseURLResolver) http.Hand
 // NewProxyClientFromConfig creates a new http.Client designed for proxying requests and enforcing
 // certain minimum configuration values.
 func NewProxyClientFromConfig(config types.FaaSConfig) *http.Client {
-	maxIdleConns := config.MaxIdleConns
-	if maxIdleConns < 1 {
-		maxIdleConns = 1024
-	}
-
-	maxIdleConnsPerHost := config.MaxIdleConnsPerHost
-	if maxIdleConnsPerHost < 1 {
-		maxIdleConnsPerHost = 1024
-	}
-
-	timeout := config.ReadTimeout
-	if timeout <= 0*time.Second {
-		timeout = 10 * time.Second
-	}
-
-	return NewProxyClient(timeout, maxIdleConns, maxIdleConnsPerHost)
+	return NewProxyClient(config.GetReadTimeout(), config.GetMaxIdleConns(), config.GetMaxIdleConnsPerHost())
 }
 
 // NewProxyClient creates a new http.Client designed for proxying requests, this is exposed as a

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -479,7 +479,7 @@ func Test_NewProxyClientConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			client := NewProxyClient(tc.config)
+			client := NewProxyClientFromConfig(tc.config)
 			if client.Timeout != tc.timeout {
 				t.Fatalf("expected timeout %s, got %s", tc.timeout.String(), client.Timeout.String())
 			}

--- a/types/config.go
+++ b/types/config.go
@@ -30,10 +30,21 @@ type FaaSHandlers struct {
 
 // FaaSConfig set config for HTTP handlers
 type FaaSConfig struct {
-	TCPPort         *int
-	ReadTimeout     time.Duration
-	WriteTimeout    time.Duration
-	EnableHealth    bool
+	// TCPPort is the public port for the API.
+	TCPPort *int
+	// HTTP timeout for reading a request from clients.
+	ReadTimeout time.Duration
+	// HTTP timeout for writing a response from functions.
+	WriteTimeout time.Duration
+	// EnableHealth enables/disables the default health endpoint bound to "/healthz".
+	EnableHealth bool
+	// EnableBasicAuth enforces basic auth on the API. If set, reads secrets from file-system
+	// location specificed in `SecretMountPath`.
 	EnableBasicAuth bool
+	// SecretMountPath specifies where to read secrets from for embedded basic auth.
 	SecretMountPath string
+	// MaxIdleConns with a default value of 1024, can be used for tuning HTTP proxy performance.
+	MaxIdleConns int
+	// MaxIdleConnsPerHost with a default value of 1024, can be used for tuning HTTP proxy performance.
+	MaxIdleConnsPerHost int
 }

--- a/types/config.go
+++ b/types/config.go
@@ -5,6 +5,11 @@ import (
 	"time"
 )
 
+const (
+	defaultReadTimeout  = 10 * time.Second
+	defaultMaxIdleConns = 1024
+)
+
 // FaaSHandlers provide handlers for OpenFaaS
 type FaaSHandlers struct {
 	// FunctionProxy provides the function invocation proxy logic.  Use proxy.NewHandlerFunc to
@@ -47,4 +52,31 @@ type FaaSConfig struct {
 	MaxIdleConns int
 	// MaxIdleConnsPerHost with a default value of 1024, can be used for tuning HTTP proxy performance.
 	MaxIdleConnsPerHost int
+}
+
+// GetReadTimeout is a helper to safely return the configured ReadTimeout or the default value of 10s
+func (c *FaaSConfig) GetReadTimeout() time.Duration {
+	if c.ReadTimeout <= 0*time.Second {
+		return defaultReadTimeout
+	}
+	return c.ReadTimeout
+}
+
+// GetMaxIdleConns is a helper to safely return the configured MaxIdleConns or the default value of 1024
+func (c *FaaSConfig) GetMaxIdleConns() int {
+	if c.MaxIdleConns < 1 {
+		return defaultMaxIdleConns
+	}
+
+	return c.MaxIdleConns
+}
+
+// GetMaxIdleConns is a helper to safely return the configured MaxIdleConns or the default value which
+// should then match the MaxIdleConns
+func (c *FaaSConfig) GetMaxIdleConnsPerHost() int {
+	if c.MaxIdleConnsPerHost < 1 {
+		return c.GetMaxIdleConns()
+	}
+
+	return c.MaxIdleConnsPerHost
 }

--- a/types/read_config.go
+++ b/types/read_config.go
@@ -1,0 +1,113 @@
+package types
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// OsEnv implements interface to wrap os.Getenv
+type OsEnv struct {
+}
+
+// Getenv wraps os.Getenv
+func (OsEnv) Getenv(key string) string {
+	return os.Getenv(key)
+}
+
+// HasEnv provides interface for os.Getenv
+type HasEnv interface {
+	Getenv(key string) string
+}
+
+// ReadConfig constitutes config from env variables
+type ReadConfig struct {
+}
+
+// ParseIntValue parses the the int in val or, if there is an error, returns the
+// specified default value
+func ParseIntValue(val string, fallback int) int {
+	if len(val) > 0 {
+		parsedVal, parseErr := strconv.Atoi(val)
+		if parseErr == nil && parsedVal >= 0 {
+			return parsedVal
+		}
+	}
+	return fallback
+}
+
+// ParseIntOrDurationValue parses the the duration in val or, if there is an error, returns the
+// specified default value
+func ParseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
+	if len(val) > 0 {
+		parsedVal, parseErr := strconv.Atoi(val)
+		if parseErr == nil && parsedVal >= 0 {
+			return time.Duration(parsedVal) * time.Second
+		}
+	}
+
+	duration, durationErr := time.ParseDuration(val)
+	if durationErr != nil {
+		return fallback
+	}
+
+	return duration
+}
+
+// ParseBoolValue parses the the boolean in val or, if there is an error, returns the
+// specified default value
+func ParseBoolValue(val string, fallback bool) bool {
+	if len(val) > 0 {
+		return val == "true"
+	}
+	return fallback
+}
+
+// ParseString verifies the string in val is not empty. When empty, it returns the
+// specified default value
+func ParseString(val string, fallback string) string {
+	if len(val) > 0 {
+		return val
+	}
+	return fallback
+}
+
+// Read fetches config from environmental variables.
+func (ReadConfig) Read(hasEnv HasEnv) (*FaaSConfig, error) {
+	cfg := &FaaSConfig{
+		ReadTimeout:  ParseIntOrDurationValue(hasEnv.Getenv("read_timeout"), time.Second*10),
+		WriteTimeout: ParseIntOrDurationValue(hasEnv.Getenv("write_timeout"), time.Second*10),
+		// default value from Gateway
+		EnableBasicAuth: ParseBoolValue(hasEnv.Getenv("basic_auth"), false),
+		// default value from Gateway
+		SecretMountPath: ParseString(hasEnv.Getenv("secret_mount_path"), "/run/secrets/"),
+	}
+
+	port := ParseIntValue(hasEnv.Getenv("port"), 8080)
+	cfg.TCPPort = &port
+
+	cfg.MaxIdleConns = 1024
+	maxIdleConns := hasEnv.Getenv("max_idle_conns")
+	if len(maxIdleConns) > 0 {
+		val, err := strconv.Atoi(maxIdleConns)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for max_idle_conns: %s", maxIdleConns)
+		}
+		cfg.MaxIdleConns = val
+
+	}
+
+	cfg.MaxIdleConnsPerHost = 1024
+	maxIdleConnsPerHost := hasEnv.Getenv("max_idle_conns_per_host")
+	if len(maxIdleConnsPerHost) > 0 {
+		val, err := strconv.Atoi(maxIdleConnsPerHost)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for max_idle_conns_per_host: %s", maxIdleConnsPerHost)
+		}
+		cfg.MaxIdleConnsPerHost = val
+
+	}
+
+	return cfg, nil
+}

--- a/types/read_config_test.go
+++ b/types/read_config_test.go
@@ -1,0 +1,176 @@
+package types
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+type EnvBucket struct {
+	Items map[string]string
+}
+
+func NewEnvBucket() EnvBucket {
+	return EnvBucket{
+		Items: make(map[string]string),
+	}
+}
+
+func (e EnvBucket) Getenv(key string) string {
+	return e.Items[key]
+}
+
+func (e EnvBucket) Setenv(key string, value string) {
+	e.Items[key] = value
+}
+
+func TestRead_EmptyTimeoutConfig(t *testing.T) {
+	defaults := NewEnvBucket()
+	readConfig := ReadConfig{}
+
+	config, err := readConfig.Read(defaults)
+	if err != nil {
+		t.Fatalf("unexpected error while reading config")
+	}
+
+	if (config.ReadTimeout) != time.Duration(10)*time.Second {
+		t.Log("ReadTimeout incorrect")
+		t.Fail()
+	}
+	if (config.WriteTimeout) != time.Duration(10)*time.Second {
+		t.Log("WriteTimeout incorrect")
+		t.Fail()
+	}
+}
+
+func TestRead_ReadAndWriteTimeoutConfig(t *testing.T) {
+	defaults := NewEnvBucket()
+	defaults.Setenv("read_timeout", "5")
+	defaults.Setenv("write_timeout", "60")
+
+	readConfig := ReadConfig{}
+	config, err := readConfig.Read(defaults)
+	if err != nil {
+		t.Fatalf("unexpected error while reading config")
+	}
+
+	if (config.ReadTimeout) != time.Duration(5)*time.Second {
+		t.Logf("ReadTimeout incorrect, got: %d\n", config.ReadTimeout)
+		t.Fail()
+	}
+	if (config.WriteTimeout) != time.Duration(60)*time.Second {
+		t.Logf("WriteTimeout incorrect, got: %d\n", config.WriteTimeout)
+		t.Fail()
+	}
+}
+
+func TestRead_ReadAndWriteTimeoutDurationConfig(t *testing.T) {
+	defaults := NewEnvBucket()
+	defaults.Setenv("read_timeout", "20s")
+	defaults.Setenv("write_timeout", "1m30s")
+
+	readConfig := ReadConfig{}
+	config, err := readConfig.Read(defaults)
+	if err != nil {
+		t.Fatalf("unexpected error while reading config")
+	}
+
+	if (config.ReadTimeout) != time.Duration(20)*time.Second {
+		t.Logf("ReadTimeout incorrect, got: %d\n", config.ReadTimeout)
+		t.Fail()
+	}
+	if (config.WriteTimeout) != time.Duration(90)*time.Second {
+		t.Logf("WriteTimeout incorrect, got: %d\n", config.WriteTimeout)
+		t.Fail()
+	}
+}
+
+func TestRead_BasicAuthDefaults(t *testing.T) {
+	defaults := NewEnvBucket()
+
+	readConfig := ReadConfig{}
+
+	config, err := readConfig.Read(defaults)
+	if err != nil {
+		t.Fatalf("unexpected error while reading config")
+	}
+
+	if config.EnableBasicAuth != false {
+		t.Logf("config.EnableBasicAuth, want: %t, got: %t\n", false, config.EnableBasicAuth)
+		t.Fail()
+	}
+
+	wantSecretsMount := "/run/secrets/"
+	if config.SecretMountPath != wantSecretsMount {
+		t.Logf("config.SecretMountPath, want: %s, got: %s\n", wantSecretsMount, config.SecretMountPath)
+		t.Fail()
+	}
+}
+
+func TestRead_BasicAuth_SetTrue(t *testing.T) {
+	defaults := NewEnvBucket()
+	defaults.Setenv("basic_auth", "true")
+	defaults.Setenv("secret_mount_path", "/etc/openfaas/")
+
+	readConfig := ReadConfig{}
+
+	config, err := readConfig.Read(defaults)
+	if err != nil {
+		t.Fatalf("unexpected error while reading config")
+	}
+
+	if config.EnableBasicAuth != true {
+		t.Logf("config.EnableBasicAuth, want: %t, got: %t\n", true, config.EnableBasicAuth)
+		t.Fail()
+	}
+
+	wantSecretsMount := "/etc/openfaas/"
+	if config.SecretMountPath != wantSecretsMount {
+		t.Logf("config.SecretMountPath, want: %s, got: %s\n", wantSecretsMount, config.SecretMountPath)
+		t.Fail()
+	}
+}
+
+func TestRead_MaxIdleConnsDefaults(t *testing.T) {
+	defaults := NewEnvBucket()
+
+	readConfig := ReadConfig{}
+
+	config, err := readConfig.Read(defaults)
+	if err != nil {
+		t.Fatalf("unexpected error while reading config")
+	}
+
+	if config.MaxIdleConns != 1024 {
+		t.Logf("config.MaxIdleConns, want: %d, got: %d\n", 1024, config.MaxIdleConns)
+		t.Fail()
+	}
+
+	if config.MaxIdleConnsPerHost != 1024 {
+		t.Logf("config.MaxIdleConnsPerHost, want: %d, got: %d\n", 1024, config.MaxIdleConnsPerHost)
+		t.Fail()
+	}
+}
+
+func TestRead_MaxIdleConns_Override(t *testing.T) {
+	defaults := NewEnvBucket()
+
+	readConfig := ReadConfig{}
+	defaults.Setenv("max_idle_conns", fmt.Sprintf("%d", 100))
+	defaults.Setenv("max_idle_conns_per_host", fmt.Sprintf("%d", 2))
+
+	config, err := readConfig.Read(defaults)
+	if err != nil {
+		t.Fatalf("unexpected error while reading config")
+	}
+
+	if config.MaxIdleConns != 100 {
+		t.Logf("config.MaxIdleConns, want: %d, got: %d\n", 100, config.MaxIdleConns)
+		t.Fail()
+	}
+
+	if config.MaxIdleConnsPerHost != 2 {
+		t.Logf("config.MaxIdleConnsPerHost, want: %d, got: %d\n", 2, config.MaxIdleConnsPerHost)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
- This pulls the http Client configuration from the gateway into the
provider proxy client. This will specifically allow the reuse of
connections and CoreDNS rate limiting
- Additionally, it ports the ReadConfig pattern and helper methods from the gateway
to the provider. This pattern and methods are mimicked in the Gateway and
the provider, so this can help reduce the duplication and boilerplate
code in these projects.  This also helps to ensure that there are
consistent env parsing and defaults in the providers

Resolves #34

The changes are split across two commits, if you would like to keep it split. The motivation for the second config related changes is due to changing the proxy constructor taking the `FaaSConfig` as an argument.  I thought it would be appropriate to also then provide a consistent way to construct that config.