### PR TITLE
Deprecate enable_health flag

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -72,7 +72,7 @@ func Serve(handlers *types.FaaSHandlers, config *types.FaaSConfig) {
 	r.HandleFunc("/function/{name:["+NameExpression+"]+}/", handlers.FunctionProxy)
 	r.HandleFunc("/function/{name:["+NameExpression+"]+}/{params:.*}", handlers.FunctionProxy)
 
-	if config.EnableHealth {
+	if handlers.HealthHandler != nil {
 		r.HandleFunc("/healthz", handlers.HealthHandler).Methods("GET")
 	}
 

--- a/types/config.go
+++ b/types/config.go
@@ -27,7 +27,9 @@ type FaaSHandlers struct {
 	LogHandler http.HandlerFunc
 
 	// UpdateHandler an existing function/service
-	UpdateHandler        http.HandlerFunc
+	UpdateHandler http.HandlerFunc
+	// HealthHandler defines the default health endpoint bound to "/healthz
+	// If the handler is not set, then the "/healthz" path will not be configured
 	HealthHandler        http.HandlerFunc
 	InfoHandler          http.HandlerFunc
 	ListNamespaceHandler http.HandlerFunc
@@ -42,6 +44,9 @@ type FaaSConfig struct {
 	// HTTP timeout for writing a response from functions.
 	WriteTimeout time.Duration
 	// EnableHealth enables/disables the default health endpoint bound to "/healthz".
+	//
+	// Deprecated: basic auth is enabled automatcally by setting the HealthHandler in the FaaSHandlers
+	// struct.  This value is not longer read or used.
 	EnableHealth bool
 	// EnableBasicAuth enforces basic auth on the API. If set, reads secrets from file-system
 	// location specificed in `SecretMountPath`.

--- a/types/read_config.go
+++ b/types/read_config.go
@@ -76,9 +76,8 @@ func ParseString(val string, fallback string) string {
 // Read fetches config from environmental variables.
 func (ReadConfig) Read(hasEnv HasEnv) (*FaaSConfig, error) {
 	cfg := &FaaSConfig{
-		ReadTimeout:  ParseIntOrDurationValue(hasEnv.Getenv("read_timeout"), time.Second*10),
-		WriteTimeout: ParseIntOrDurationValue(hasEnv.Getenv("write_timeout"), time.Second*10),
-		// default value from Gateway
+		ReadTimeout:     ParseIntOrDurationValue(hasEnv.Getenv("read_timeout"), time.Second*10),
+		WriteTimeout:    ParseIntOrDurationValue(hasEnv.Getenv("write_timeout"), time.Second*10),
 		EnableBasicAuth: ParseBoolValue(hasEnv.Getenv("basic_auth"), false),
 		// default value from Gateway
 		SecretMountPath: ParseString(hasEnv.Getenv("secret_mount_path"), "/run/secrets/"),

--- a/types/read_config_test.go
+++ b/types/read_config_test.go
@@ -131,6 +131,21 @@ func TestRead_BasicAuth_SetTrue(t *testing.T) {
 	}
 }
 
+func TestRead_EnableHealth_Ignored(t *testing.T) {
+	defaults := NewEnvBucket()
+	defaults.Setenv("enable_health", "true")
+
+	readConfig := ReadConfig{}
+	config, err := readConfig.Read(defaults)
+	if err != nil {
+		t.Fatalf("unexpected error while reading config")
+	}
+
+	if config.EnableBasicAuth != false {
+		t.Fatalf("config.EnableHealth, is deprecated but got: %t\n", config.EnableBasicAuth)
+	}
+}
+
 func TestRead_MaxIdleConnsDefaults(t *testing.T) {
 	defaults := NewEnvBucket()
 


### PR DESCRIPTION
**What**
- Deprecate the enable_health flag in the env config. Instead, enable or
  disable if the health handler is passed. This simplifies the
  configuration and be simplier for provider implementers.  They can
  choose to add there own health check flag, if they wish, but the
  default with healthcheck will now be easier.

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>