### PR TITLE
Add InfoResponse object

### DIFF
--- a/types/requests.go
+++ b/types/requests.go
@@ -8,8 +8,8 @@ type ScaleServiceRequest struct {
 	Replicas    uint64 `json:"replicas"`
 }
 
-// InfoRequest provides information about the underlying provider
-type InfoRequest struct {
+// InfoResponse provides information about the underlying provider
+type InfoResponse struct {
 	Provider      string          `json:"provider"`
 	Version       ProviderVersion `json:"version"`
 	Orchestration string          `json:"orchestration"`


### PR DESCRIPTION
Rename `InfoRequest` to `InfoResponse` to match the intended usage for the struct and to make it easier for developers to understand how to use it.

Resolves #38