### PR TITLE
Fix namespace formatting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/openfaas/faas-provider
 go 1.13
 
 require (
-	github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f
+	github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f // indirect
 	github.com/gorilla/mux v1.6.2
+	github.com/stretchr/testify v1.5.1 // indirect
 	go.uber.org/goleak v0.10.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,17 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f h1:9oNbS1z4rVpbnkHBdPZU4jo9bSmrLpII768arSyMFgk=
 github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 go.uber.org/goleak v0.10.0 h1:G3eWbSNIskeRqtsN/1uI5B+eP73y3JUuBsv9AZjehb4=
 go.uber.org/goleak v0.10.0/go.mod h1:VCZuO8V8mFPlL0F5J5GK1rtHV3DrFcQ1R8ryq7FK0aI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -33,7 +33,7 @@ type Request struct {
 // allows you to safely compare if two requests have the same value.
 func (r Request) String() string {
 	return fmt.Sprintf(
-		"name:%s namespace: %s instance:%s since:%v tail:%d follow:%v",
+		"name: %s namespace: %s instance: %s since: %v tail: %d follow: %v",
 		r.Name, r.Namespace, r.Instance, r.Since, r.Tail, r.Follow,
 	)
 }
@@ -55,8 +55,12 @@ type Message struct {
 
 // String implements the Stringer interface and allows for nice and simple string formatting of a log Message.
 func (m Message) String() string {
+	ns := ""
+	if len(m.Namespace) > 0 {
+		ns = fmt.Sprintf("%s ", m.Namespace)
+	}
 	return fmt.Sprintf(
-		"%s %s (%s %s) %s",
-		m.Timestamp.String(), m.Name, m.Namespace, m.Instance, m.Text,
+		"%s %s (%s%s) %s",
+		m.Timestamp.String(), m.Name, ns, m.Instance, m.Text,
 	)
 }

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -1,0 +1,45 @@
+package logs
+
+import (
+	"testing"
+
+	"time"
+)
+
+func Test_Message_String_WithNS(t *testing.T) {
+
+	ts := time.Date(2019, time.November, 10, 23, 0, 0, 0, time.UTC)
+
+	m := Message{
+		Name:      "figlet",
+		Namespace: "openfaas-fn",
+		Instance:  "figlet-pod1",
+		Text:      "Watchdog started",
+		Timestamp: ts,
+	}
+
+	got := m.String()
+	want := "2019-11-10 23:00:00 +0000 UTC figlet (openfaas-fn figlet-pod1) Watchdog started"
+	if want != got {
+		t.Fatalf("want %q, got %q", want, got)
+	}
+}
+
+func Test_Message_String_WithoutNS(t *testing.T) {
+
+	ts := time.Date(2019, time.November, 10, 23, 0, 0, 0, time.UTC)
+
+	m := Message{
+		Name:      "figlet",
+		Namespace: "",
+		Instance:  "figlet-pod1",
+		Text:      "Watchdog started",
+		Timestamp: ts,
+	}
+
+	got := m.String()
+	want := "2019-11-10 23:00:00 +0000 UTC figlet (figlet-pod1) Watchdog started"
+	if want != got {
+		t.Fatalf("want %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
The namespace formatting was outputting an extra space in the
format of Message.String() and causing downstream tests to
fail in the faas-cli project. Now, the namespace is included
only if it's required.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>