### PR TITLE
migrate travis ci to github actions

### DIFF
--- a/.github/workflows/ci-only.yml
+++ b/.github/workflows/ci-only.yml
@@ -1,0 +1,21 @@
+name: ci-only
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        go-version: [1.13.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Run CI
+        run: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: go
-
-go:
-  - 1.13.x
-
-go_import_path: github.com/openfaas/faas-provider
-script:
-  - make test
-


### PR DESCRIPTION
Signed-off-by: Nitishkumar Singh <nitishkumarsingh71@gmail.com>

**Description**

We want to migrate from Travis CI to Github Actions
Fixes #48 
**How Has This Been Tested?**

Please check [CI Only Build](https://github.com/nitishkumar71/faas-provider/runs/1368060848?check_suite_focus=true)