### PR TITLE
Add test and fix the returned Content-Type from proxyRequest

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -173,7 +173,7 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 
 	clientHeader := w.Header()
 	copyHeaders(clientHeader, &response.Header)
-	w.Header().Set("Content-Type", getContentType(response.Header, originalReq.Header))
+	w.Header().Set("Content-Type", getContentType(originalReq.Header, response.Header))
 
 	w.WriteHeader(response.StatusCode)
 	io.Copy(w, response.Body)


### PR DESCRIPTION
Fixes https://github.com/openfaas/faasd/issues/136

### Description
The PR adds a unit test that tests if the Content-Type returned by the proxy behaves as per the headers set by the function or the watchdog. The call to getContentType in proxyRequest has it's order of arguments in the reverse order and needs to be fixed.

Switching the two arguments will fix the issue, but I've written a test that fails as of now because of the order of the arguments passed into the function getContentType.

Signed-off-by: Utsav Anand <utsavanand2@gmail.com>