### PR TITLE
fix: ensure WriteInterceptor always  sets a valid status code

### DIFF
--- a/httputil/write_interceptor.go
+++ b/httputil/write_interceptor.go
@@ -12,14 +12,14 @@ func NewHttpWriteInterceptor(w http.ResponseWriter) *HttpWriteInterceptor {
 
 type HttpWriteInterceptor struct {
 	http.ResponseWriter
-	StatusCode int
+	statusCode int
 }
 
 func (c *HttpWriteInterceptor) Status() int {
-	if c.StatusCode == 0 {
+	if c.statusCode == 0 {
 		return http.StatusOK
 	}
-	return c.StatusCode
+	return c.statusCode
 }
 
 func (c *HttpWriteInterceptor) Header() http.Header {
@@ -27,11 +27,14 @@ func (c *HttpWriteInterceptor) Header() http.Header {
 }
 
 func (c *HttpWriteInterceptor) Write(data []byte) (int, error) {
+	if c.statusCode == 0 {
+		c.WriteHeader(http.StatusOK)
+	}
 	return c.ResponseWriter.Write(data)
 }
 
 func (c *HttpWriteInterceptor) WriteHeader(code int) {
-	c.StatusCode = code
+	c.statusCode = code
 	c.ResponseWriter.WriteHeader(code)
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -53,7 +53,7 @@ func (hm *httpMetrics) InstrumentHandler(next http.Handler, pathOverride string)
 
 		defer func() {
 			hm.RequestsTotal.With(
-				prometheus.Labels{"code": strconv.Itoa(ww.StatusCode),
+				prometheus.Labels{"code": strconv.Itoa(ww.Status()),
 					"method": r.Method,
 					"path":   path,
 				}).
@@ -62,7 +62,7 @@ func (hm *httpMetrics) InstrumentHandler(next http.Handler, pathOverride string)
 
 		defer func() {
 			hm.RequestDurationHistogram.With(
-				prometheus.Labels{"code": strconv.Itoa(ww.StatusCode),
+				prometheus.Labels{"code": strconv.Itoa(ww.Status()),
 					"method": r.Method,
 					"path":   path,
 				}).


### PR DESCRIPTION
Ensure that the metrics record the correct status code, instead of the
invalid 0 value. This replicates the stdlib behavior of setting the 200
code on first write, if it is the first write.

The stats code is also moved to a private method to ensure that users
always use the Status() method instead.

Resolves #65

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>