### PR TITLE
Rename handlers to match how they are used

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This faas-provider can be used to write your own back-end for OpenFaaS. The Gola
 
 The faas-provider provides CRUD for functions and an invoke capability. If you complete the required endpoints then you will be able to use your container orchestrator or back-end system with the existing OpenFaaS ecosystem and tooling.
 
-> See also: [backends guide](https://github.com/openfaas/faas/blob/master/guide/deprecated/backends.md)
+Read more: [The power of interfaces in OpenFaaS](https://blog.alexellis.io/the-power-of-interfaces-openfaas/)
 
 ### Recommendations
 
@@ -27,14 +27,18 @@ I.e.:
 ```go
 	timeout := 8 * time.Second
 	bootstrapHandlers := bootTypes.FaaSHandlers{
-		FunctionProxy:  handlers.MakeProxy(),
-		DeleteHandler:  handlers.MakeDeleteHandler(clientset),
-		DeployHandler:  handlers.MakeDeployHandler(clientset),
-		FunctionReader: handlers.MakeFunctionReader(clientset),
-		ReplicaReader:  handlers.MakeReplicaReader(clientset),
-		ReplicaUpdater: handlers.MakeReplicaUpdater(clientset),
-		InfoHandler:    handlers.MakeInfoHandler(),
-		LogHandler: logs.NewLogHandlerFunc(requestor,timeout),
+		ListNamespaces: handlers.MakeNamespaceLister(),
+		FunctionProxy:  handlers.MakeProxyHandler(),
+		FunctionLister: handlers.MakeFunctionLister(),
+		DeployFunction: handlers.MakeDeployFunctionHandler(),
+		DeleteFunction: handlers.MakeDeleteFunctionHandler(),
+		UpdateFunction: handlers.MakeUpdateFunctionHandler(),
+		FunctionStatus: handlers.MakeFunctionStatusHandler(),
+		ScaleFunction: 	handlers.MakeScaleFunctionHandler(),
+		Secrets: 	  	handlers.MakeSecretHandler(),
+		Logs: 			handlers.MakeLogsHandler(),
+		Info: 			handlers.MakeInfoHandler(),
+		Health: 		handlers.MakeHealthHandler(),
 	}
 
 	var port int
@@ -48,6 +52,3 @@ I.e.:
 	bootstrap.Serve(&bootstrapHandlers, &bootstrapConfig)
 ```
 
-### Need help?
-
-Join `#faas-provider` on [OpenFaaS Slack](https://docs.openfaas.com/community/)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -7,15 +7,16 @@
 //
 // openfaas-provider has implemented a standard HTTP HandlerFunc that will handle setting
 // timeout values, parsing the request path, and copying the request/response correctly.
-// 		bootstrapHandlers := bootTypes.FaaSHandlers{
-// 			FunctionProxy:  proxy.NewHandlerFunc(timeout, resolver),
-// 			DeleteHandler:  handlers.MakeDeleteHandler(clientset),
-// 			DeployHandler:  handlers.MakeDeployHandler(clientset),
-// 			FunctionReader: handlers.MakeFunctionReader(clientset),
-// 			ReplicaReader:  handlers.MakeReplicaReader(clientset),
-// 			ReplicaUpdater: handlers.MakeReplicaUpdater(clientset),
-// 			InfoHandler:    handlers.MakeInfoHandler(),
-// 		}
+//
+//	bootstrapHandlers := bootTypes.FaaSHandlers{
+//		FunctionProxy:  proxy.NewHandlerFunc(timeout, resolver),
+//		DeleteHandler:  handlers.MakeDeleteHandler(clientset),
+//		DeployHandler:  handlers.MakeDeployHandler(clientset),
+//		FunctionLister: handlers.MakeFunctionLister(clientset),
+//		ReplicaReader:  handlers.MakeReplicaReader(clientset),
+//		ReplicaUpdater: handlers.MakeReplicaUpdater(clientset),
+//		InfoHandler:    handlers.MakeInfoHandler(),
+//	}
 //
 // proxy.NewHandlerFunc is optional, but does simplify the logic of your provider.
 package proxy
@@ -50,11 +51,11 @@ type BaseURLResolver interface {
 // NewHandlerFunc creates a standard http.HandlerFunc to proxy function requests.
 // The returned http.HandlerFunc will ensure:
 //
-// 	- proper proxy request timeouts
-// 	- proxy requests for GET, POST, PATCH, PUT, and DELETE
-// 	- path parsing including support for extracing the function name, sub-paths, and query paremeters
-// 	- passing and setting the `X-Forwarded-Host` and `X-Forwarded-For` headers
-// 	- logging errors and proxy request timing to stdout
+//   - proper proxy request timeouts
+//   - proxy requests for GET, POST, PATCH, PUT, and DELETE
+//   - path parsing including support for extracing the function name, sub-paths, and query paremeters
+//   - passing and setting the `X-Forwarded-Host` and `X-Forwarded-For` headers
+//   - logging errors and proxy request timing to stdout
 //
 // Note that this will panic if `resolver` is nil.
 func NewHandlerFunc(config types.FaaSConfig, resolver BaseURLResolver) http.HandlerFunc {

--- a/types/config.go
+++ b/types/config.go
@@ -12,27 +12,37 @@ const (
 
 // FaaSHandlers provide handlers for OpenFaaS
 type FaaSHandlers struct {
+	ListNamespaces http.HandlerFunc
+
 	// FunctionProxy provides the function invocation proxy logic.  Use proxy.NewHandlerFunc to
 	// use the standard OpenFaaS proxy implementation or provide completely custom proxy logic.
 	FunctionProxy http.HandlerFunc
 
-	FunctionReader http.HandlerFunc
-	DeployHandler  http.HandlerFunc
+	// FunctionLister lists deployed functions within a namespace
+	FunctionLister http.HandlerFunc
 
-	DeleteHandler  http.HandlerFunc
-	ReplicaReader  http.HandlerFunc
-	ReplicaUpdater http.HandlerFunc
-	SecretHandler  http.HandlerFunc
-	// LogHandler provides streaming json logs of functions
-	LogHandler http.HandlerFunc
+	// DeployFunction deploys a function which doesn't exist
+	DeployFunction http.HandlerFunc
 
-	// UpdateHandler an existing function/service
-	UpdateHandler http.HandlerFunc
-	// HealthHandler defines the default health endpoint bound to "/healthz
+	// UpdateFunction updates an existing function
+	UpdateFunction http.HandlerFunc
+
+	DeleteFunction http.HandlerFunc
+
+	FunctionStatus http.HandlerFunc
+
+	ScaleFunction http.HandlerFunc
+
+	Secrets http.HandlerFunc
+
+	// Logs provides streaming json logs of functions
+	Logs http.HandlerFunc
+
+	// Health defines the default health endpoint bound to "/healthz
 	// If the handler is not set, then the "/healthz" path will not be configured
-	HealthHandler        http.HandlerFunc
-	InfoHandler          http.HandlerFunc
-	ListNamespaceHandler http.HandlerFunc
+	Health http.HandlerFunc
+
+	Info http.HandlerFunc
 }
 
 // FaaSConfig set config for HTTP handlers


### PR DESCRIPTION
## Description

Rename handlers to match how they are used

## Why is this needed?

The legacy names can now be updated to more intuitive versions.

## Impact to existing users

Stay on the previous version, or when upgrading, change the names provided to the SDK i.e. 

FunctionReader => FunctionLister
ReplicasReader => ScaleFunction

A diff on the README between releases shows all of the renamed variables.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>