### PR TITLE
Add function ParseIntOrDuration

### DIFF
--- a/types/read_config.go
+++ b/types/read_config.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -53,6 +54,26 @@ func ParseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
 	}
 
 	return duration
+}
+
+// ParseIntOrDurationValue interprets a string representing an int or duration and returns
+// an int as the number of seconds. An error is returned if val can not be parsed as int or duration.
+func ParseIntOrDuration(val string) (int, error) {
+	i, err := strconv.ParseInt(val, 10, 0)
+	if err == nil {
+		return int(i), nil
+	}
+
+	if err != nil && errors.Is(err, strconv.ErrRange) {
+		return int(i), err
+	}
+
+	d, err := time.ParseDuration(val)
+	if err != nil {
+		return 0, err
+	}
+
+	return int(d.Seconds()), nil
 }
 
 // ParseBoolValue parses the the boolean in val or, if there is an error, returns the

--- a/types/read_config_test.go
+++ b/types/read_config_test.go
@@ -189,3 +189,50 @@ func TestRead_MaxIdleConns_Override(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func Test_ParseIntOrDuration(t *testing.T) {
+	tests := []struct {
+		val  string
+		want int
+		err  bool
+	}{
+		{
+			val:  "1m",
+			want: 60,
+			err:  false,
+		},
+		{
+			val:  "30",
+			want: 30,
+			err:  false,
+		},
+		{
+			val:  "invalid",
+			want: 0,
+			err:  true,
+		},
+		{
+			val:  "9223372036854775808",
+			want: 0,
+			err:  true,
+		},
+	}
+
+	for _, test := range tests {
+		got, err := ParseIntOrDuration(test.val)
+
+		if test.err {
+			if err == nil {
+				t.Errorf("parseIntOrDuration(%s) should have returned an error", test.val)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("parseIntOrDuration(%s) returned an unexpected error: %v", test.val, err)
+			}
+
+			if test.want != got {
+				t.Errorf("parseIntOrDuration(%s) returned %d, wanted %d", test.val, got, test.want)
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Alternative for `ParseInOrDurationValue` that returns an error instead of a default value if the string can not be parsed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Moved to this package from faas-netes pro to make reuse possible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Covered by unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
