### PR TITLE
Add namespace mutation

### DIFF
--- a/types/config.go
+++ b/types/config.go
@@ -12,7 +12,12 @@ const (
 
 // FaaSHandlers provide handlers for OpenFaaS
 type FaaSHandlers struct {
+	// ListNamespace lists namespaces which are annotated for OpenFaaS
 	ListNamespaces http.HandlerFunc
+
+	// MutateNamespace mutates a namespace to be annotated for OpenFaaS
+	// each namespace must contain an annotation of "openfaas=1"
+	MutateNamespace http.HandlerFunc
 
 	// FunctionProxy provides the function invocation proxy logic.  Use proxy.NewHandlerFunc to
 	// use the standard OpenFaaS proxy implementation or provide completely custom proxy logic.

--- a/types/requests.go
+++ b/types/requests.go
@@ -27,3 +27,12 @@ type VersionInfo struct {
 	SHA           string `json:"sha"`
 	Release       string `json:"release"`
 }
+
+// FunctionNamespace is required for use with the /system/namespace/NAME endpoint
+// for deletions, just pass the namespace field.
+type FunctionNamespace struct {
+	Namespace string `json:"namespace"`
+
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+}


### PR DESCRIPTION
## Description

Add namespace mutation endpoints for create, delete, update.

## Why is this needed?

Useful for OfE customers who are running a multi-tenant OpenFaaS system.

This may also get implemented in faasd which has multiple-namespace support.

## Testing

CI unit tests only at the moment

## Docs

The OpenAPI spec will need to be updated with the new endpoint and its verbs.

POST - create
PUT - update
DELETE - remove
GET - get a specific item

Endpoint: `/system/namespace/NAME`