### PR TITLE
Add a header to mark when a response is from openfaas

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -137,7 +137,7 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 	pathVars := mux.Vars(originalReq)
 	functionName := pathVars["name"]
 	if functionName == "" {
-		w.Header().Add("x-openfaas-internal", "proxy")
+		w.Header().Add("X-OpenFaaS-Internal", "proxy")
 
 		httputil.Errorf(w, http.StatusBadRequest, "Provide function name in the request path")
 		return
@@ -145,7 +145,7 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 
 	functionAddr, err := resolver.Resolve(functionName)
 	if err != nil {
-		w.Header().Add("x-openfaas-internal", "proxy")
+		w.Header().Add("X-OpenFaaS-Internal", "proxy")
 
 		// TODO: Should record the 404/not found error in Prometheus.
 		log.Printf("resolver error: no endpoints for %s: %s\n", functionName, err.Error())
@@ -156,7 +156,7 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 	proxyReq, err := buildProxyRequest(originalReq, functionAddr, pathVars["params"])
 	if err != nil {
 
-		w.Header().Add("x-openfaas-internal", "proxy")
+		w.Header().Add("X-OpenFaaS-Internal", "proxy")
 
 		httputil.Errorf(w, http.StatusInternalServerError, "Failed to resolve service: %s.", functionName)
 		return
@@ -173,7 +173,7 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 	if err != nil {
 		log.Printf("error with proxy request to: %s, %s\n", proxyReq.URL.String(), err.Error())
 
-		w.Header().Add("x-openfaas-internal", "proxy")
+		w.Header().Add("X-OpenFaaS-Internal", "proxy")
 
 		httputil.Errorf(w, http.StatusInternalServerError, "Can't reach service for: %s.", functionName)
 		return

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -3,7 +3,7 @@ package proxy
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -186,7 +186,7 @@ func Test_buildProxyRequest_Body_Method_Query(t *testing.T) {
 		t.Fail()
 	}
 
-	upstreamBytes, _ := ioutil.ReadAll(upstream.Body)
+	upstreamBytes, _ := io.ReadAll(upstream.Body)
 
 	if string(upstreamBytes) != string(srcBytes) {
 		t.Errorf("Body - want: %s, got: %s", string(upstreamBytes), string(srcBytes))
@@ -357,7 +357,7 @@ func Test_buildProxyRequest_WithPathNoQuery(t *testing.T) {
 		t.Fail()
 	}
 
-	upstreamBytes, _ := ioutil.ReadAll(upstream.Body)
+	upstreamBytes, _ := io.ReadAll(upstream.Body)
 
 	if string(upstreamBytes) != string(srcBytes) {
 		t.Errorf("Body - want: %s, got: %s", string(upstreamBytes), string(srcBytes))
@@ -409,7 +409,7 @@ func Test_buildProxyRequest_WithNoPathNoQuery(t *testing.T) {
 		t.Fail()
 	}
 
-	upstreamBytes, _ := ioutil.ReadAll(upstream.Body)
+	upstreamBytes, _ := io.ReadAll(upstream.Body)
 
 	if string(upstreamBytes) != string(srcBytes) {
 		t.Errorf("Body - want: %s, got: %s", string(upstreamBytes), string(srcBytes))
@@ -459,7 +459,7 @@ func Test_buildProxyRequest_WithPathAndQuery(t *testing.T) {
 		t.Fail()
 	}
 
-	upstreamBytes, _ := ioutil.ReadAll(upstream.Body)
+	upstreamBytes, _ := io.ReadAll(upstream.Body)
 
 	if string(upstreamBytes) != string(srcBytes) {
 		t.Errorf("Body - want: %s, got: %s", string(upstreamBytes), string(srcBytes))


### PR DESCRIPTION
Add a header to mark when a response is from openfaas

* The function proxy will now add an extra header to show when an error occurred during invocation.
* Added unit tests and peer reviewed with @welteki