### PR TITLE
Support ndjson streams for function invocations

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -528,3 +528,83 @@ func Test_NewProxyClientConfig(t *testing.T) {
 		})
 	}
 }
+
+func Test_requiresStdlibProxy(t *testing.T) {
+	testCases := []struct {
+		name    string
+		headers map[string]string
+		want    bool
+	}{
+		{
+			name:    "SSE request",
+			headers: map[string]string{"Accept": "text/event-stream"},
+			want:    true,
+		},
+		{
+			name:    "SSE request with multiple accept values",
+			headers: map[string]string{"Accept": "application/json, text/event-stream;q=0.9, text/plain"},
+			want:    true,
+		},
+		{
+			name:    "NDJSON request",
+			headers: map[string]string{"Accept": "application/x-ndjson"},
+			want:    true,
+		},
+		{
+			name:    "NDJSON request with multiple accept values",
+			headers: map[string]string{"Accept": "text/plain, application/x-ndjson;q=0.9, application/json;q=0.8"},
+			want:    true,
+		},
+		{
+			name:    "WebSocket request",
+			headers: map[string]string{"Upgrade": "websocket"},
+			want:    true,
+		},
+		{
+			name:    "Regular JSON request",
+			headers: map[string]string{"Accept": "application/json"},
+			want:    false,
+		},
+		{
+			name:    "Regular request with multiple values",
+			headers: map[string]string{"Accept": "text/plain, application/json;q=0.9"},
+			want:    false,
+		},
+		{
+			name:    "Request without headers",
+			headers: map[string]string{},
+			want:    false,
+		},
+		{
+			name:    "Request with non-websocket Upgrade header",
+			headers: map[string]string{"Accept": "application/json", "Upgrade": "h2c"},
+			want:    false,
+		},
+
+		{
+			name:    "Case insensitive headers",
+			headers: map[string]string{"Accept": "APPLICATION/X-NDJSON"},
+			want:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", "/function/test", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Set headers from test case
+			for key, value := range tc.headers {
+				req.Header.Set(key, value)
+			}
+
+			got := requiresStdlibProxy(req)
+
+			if got != tc.want {
+				t.Errorf("Want %t, got %t", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add support for streaming Newline Delimited JSON (NDJSON) from functions.

Additional fixes:
- Support Accept headers with multiple Accept values
- Accept header values should be matched case insensitive.
  As stated in [RFC 7321](https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.1) Media Types are case insensitive

## How has this been tested

A unit test was added.

Tested E2E with OpenFaaS Pro and a custom Go function that streams an NDJSON response.