### PR TITLE
Add Labels and Environment fields to QueueRequest struct

### DIFF
--- a/types/queue.go
+++ b/types/queue.go
@@ -32,9 +32,17 @@ type QueueRequest struct {
 	// for default.
 	QueueName string `json:"QueueName,omitempty"`
 
-	// Annotations defines a collection of meta-data that can be used by
-	// the queue worker when processing the queued request.
+	// Subset of annotations to pass on to the queue-worker
+	// for processing the queued request.
 	Annotations map[string]string `json:"Annotations,omitempty"`
+
+	// Subset of labels to pass on to the queue-worker
+	// for processing the queued request.
+	Labels map[string]string `json:"Labels,omitempty"`
+
+	// Subset of environment variables to pass on to the queue-worker
+	// for processing the queued request.
+	Environment map[string]string `json:"Environment,omitempty"`
 
 	// Used by queue worker to submit a result
 	CallbackURL *url.URL `json:"CallbackUrl,omitempty"`


### PR DESCRIPTION
## Description

Add Labels and Environment fields to QueueRequest struct.

This allows us to pass additional metadata for a function to the queue-worker.

## Motivation and context

This change is required for the adaptive concurrency feature of the queue-worker.