### PR TITLE
Update default HTTP client transport settings

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -129,13 +129,11 @@ func NewProxyClient(timeout time.Duration, maxIdleConns int, maxIdleConnsPerHost
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
-				Timeout:   timeout,
-				KeepAlive: 1 * time.Second,
-				DualStack: true,
+				Timeout: timeout,
 			}).DialContext,
 			MaxIdleConns:          maxIdleConns,
 			MaxIdleConnsPerHost:   maxIdleConnsPerHost,
-			IdleConnTimeout:       120 * time.Millisecond,
+			IdleConnTimeout:       5 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1500 * time.Millisecond,
 		},


### PR DESCRIPTION
## Description

Remove deprecated `DualStack` dialer field and unnecessary `KeepAlive` override. Increase `IdleConnTimeout` from 120ms to 5s for more efficient connection reuse.

## Motivation and context

- The `DualStack` field on `net.Dialer` has been deprecated since Go 1.16 and is a no-op.
- The short `KeepAlive` of 1s was unnecessarily aggressive; the Go default (15s) is more appropriate.
- The `IdleConnTimeout` of 120ms was too short, causing idle connections to be closed prematurely and increasing connection churn under load.

## How has this been tested?

The changes were vendored into faas-netes Pro and tested with a load test.